### PR TITLE
Type Registrations fail after DI-Container is built

### DIFF
--- a/ExampleCalculatorApp/App.xaml.cs
+++ b/ExampleCalculatorApp/App.xaml.cs
@@ -5,10 +5,41 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using ExampleCalculatorApp.ViewModels;
+using ExampleCalculatorApp.ViewModels.Nodes;
+using ExampleCalculatorApp.Views;
+using NodeNetwork.Utilities;
+using NodeNetwork.Views;
+using ReactiveUI;
+using Splat;
 
 namespace ExampleCalculatorApp
 {
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            InitSplatContainer();
+
+            base.OnStartup(e);
+        }
+
+        private void InitSplatContainer()
+        {
+            var container = Locator.CurrentMutable;
+            
+            // Register NodeNetwork components. 
+            container.UseNodeNetwork();
+            
+            // Register custom components. 
+            container.Register(() => new MainWindow(), typeof(IViewFor<MainViewModel>));
+            container.Register(() => new IntegerValueEditorView(), typeof(IViewFor<IntegerValueEditorViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<ConstantNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<DivisionNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<OutputNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<ProductNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<SubtractionNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<SumNodeViewModel>));
+        }
     }
 }

--- a/ExampleCalculatorApp/ViewModels/IntegerValueEditorViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/IntegerValueEditorViewModel.cs
@@ -6,11 +6,6 @@ namespace ExampleCalculatorApp.ViewModels
 {
     public class IntegerValueEditorViewModel : ValueEditorViewModel<int?>
     {
-        static IntegerValueEditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new IntegerValueEditorView(), typeof(IViewFor<IntegerValueEditorViewModel>));
-        }
-
         public IntegerValueEditorViewModel()
         {
             Value = 0;

--- a/ExampleCalculatorApp/ViewModels/MainViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/MainViewModel.cs
@@ -17,11 +17,6 @@ namespace ExampleCalculatorApp.ViewModels
 {
     public class MainViewModel : ReactiveObject
     {
-        static MainViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new MainWindow(), typeof(IViewFor<MainViewModel>));
-        }
-
         public NodeListViewModel ListViewModel { get; } = new NodeListViewModel();
         public NetworkViewModel NetworkViewModel { get; } = new NetworkViewModel();
 

--- a/ExampleCalculatorApp/ViewModels/Nodes/ConstantNodeViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/Nodes/ConstantNodeViewModel.cs
@@ -8,11 +8,6 @@ namespace ExampleCalculatorApp.ViewModels.Nodes
 {
     public class ConstantNodeViewModel : NodeViewModel
     {
-        static ConstantNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<ConstantNodeViewModel>));
-        }
-
         public IntegerValueEditorViewModel ValueEditor { get; } = new IntegerValueEditorViewModel();
 
         public ValueNodeOutputViewModel<int?> Output { get; }

--- a/ExampleCalculatorApp/ViewModels/Nodes/DivisionNodeViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/Nodes/DivisionNodeViewModel.cs
@@ -10,11 +10,6 @@ namespace ExampleCalculatorApp.ViewModels.Nodes
 {
     public class DivisionNodeViewModel : NodeViewModel
     {
-        static DivisionNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<DivisionNodeViewModel>));
-        }
-
         public ValueNodeInputViewModel<int?> Input1 { get; }
         public ValueNodeInputViewModel<int?> Input2 { get; }
         public ValueNodeOutputViewModel<int?> Output { get; }

--- a/ExampleCalculatorApp/ViewModels/Nodes/OutputNodeViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/Nodes/OutputNodeViewModel.cs
@@ -8,11 +8,6 @@ namespace ExampleCalculatorApp.ViewModels.Nodes
 {
     public class OutputNodeViewModel : NodeViewModel
     {
-        static OutputNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<OutputNodeViewModel>));
-        }
-
         public ValueNodeInputViewModel<int?> ResultInput { get; }
 
         public OutputNodeViewModel()

--- a/ExampleCalculatorApp/ViewModels/Nodes/ProductNodeViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/Nodes/ProductNodeViewModel.cs
@@ -9,11 +9,6 @@ namespace ExampleCalculatorApp.ViewModels.Nodes
 {
     public class ProductNodeViewModel : NodeViewModel
     {
-        static ProductNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<ProductNodeViewModel>));
-        }
-
         public ValueNodeInputViewModel<int?> Input1 { get; }
         public ValueNodeInputViewModel<int?> Input2 { get; }
         public ValueNodeOutputViewModel<int?> Output { get; }

--- a/ExampleCalculatorApp/ViewModels/Nodes/SubtractionNodeViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/Nodes/SubtractionNodeViewModel.cs
@@ -9,11 +9,6 @@ namespace ExampleCalculatorApp.ViewModels.Nodes
 {
     public class SubtractionNodeViewModel : NodeViewModel
     {
-        static SubtractionNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<SubtractionNodeViewModel>));
-        }
-
         public ValueNodeInputViewModel<int?> Input1 { get; }
         public ValueNodeInputViewModel<int?> Input2 { get; }
         public ValueNodeOutputViewModel<int?> Output { get; }

--- a/ExampleCalculatorApp/ViewModels/Nodes/SumNodeViewModel.cs
+++ b/ExampleCalculatorApp/ViewModels/Nodes/SumNodeViewModel.cs
@@ -9,11 +9,6 @@ namespace ExampleCalculatorApp.ViewModels.Nodes
 {
     public class SumNodeViewModel : NodeViewModel
     {
-        static SumNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<SumNodeViewModel>));
-        }
-
         public ValueNodeInputViewModel<int?> Input1 { get; }
         public ValueNodeInputViewModel<int?> Input2 { get; }
         public ValueNodeOutputViewModel<int?> Output { get; }

--- a/ExampleCodeGenApp/App.xaml.cs
+++ b/ExampleCodeGenApp/App.xaml.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
+using ExampleCodeGenApp.ViewModels;
+using ExampleCodeGenApp.ViewModels.Editors;
+using ExampleCodeGenApp.ViewModels.Nodes;
+using ExampleCodeGenApp.Views;
+using ExampleCodeGenApp.Views.Editors;
+using NodeNetwork.Utilities;
+using ReactiveUI;
+using Splat;
 
 namespace ExampleCodeGenApp
 {
@@ -13,5 +15,37 @@ namespace ExampleCodeGenApp
     /// </summary>
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            InitSplatContainer();
+
+            base.OnStartup(e);
+        }
+
+        private void InitSplatContainer()
+        {
+            var container = Locator.CurrentMutable;
+
+            // Register NodeNetwork components. 
+            container.UseNodeNetwork();
+            
+            // Register custom components. 
+            container.Register(() => new CodeGenConnectionView(), typeof(IViewFor<CodeGenConnectionViewModel>));
+            container.Register(() => new CodeGenNodeView(), typeof(IViewFor<CodeGenNodeViewModel>));
+            container.Register(() => new CodeGenPendingConnectionView(), typeof(IViewFor<CodeGenPendingConnectionViewModel>));
+            container.Register(() => new CodeGenPortView(), typeof(IViewFor<CodeGenPortViewModel>));
+            container.Register(() => new IntegerValueEditorView(), typeof(IViewFor<IntegerValueEditorViewModel>));
+            container.Register(() => new StringValueEditorView(), typeof(IViewFor<StringValueEditorViewModel>));
+            container.Register(() => new CodeGenNodeView(), typeof(IViewFor<ButtonEventNode>));
+            container.Register(() => new CodeGenNodeView(), typeof(IViewFor<ForLoopNode>));
+            container.Register(() => new CodeGenNodeView(), typeof(IViewFor<IntLiteralNode>));
+            container.Register(() => new CodeGenNodeView(), typeof(IViewFor<PrintNode>));
+            container.Register(() => new CodeGenNodeView(), typeof(IViewFor<TextLiteralNode>));
+
+            // ToDo - How do you add open generics to splat container? 
+            /* container.Register(() => new NodeInputView(), typeof(IViewFor<CodeGenInputViewModel<>>));
+            container.Register(() => new NodeInputView(), typeof(IViewFor<CodeGenListInputViewModel<>>));
+            container.Register(() => new NodeOutputView(), typeof(IViewFor<CodeGenOutputViewModel<>>));*/ 
+        }
     }
 }

--- a/ExampleCodeGenApp/ViewModels/CodeGenConnectionViewModel.cs
+++ b/ExampleCodeGenApp/ViewModels/CodeGenConnectionViewModel.cs
@@ -11,11 +11,6 @@ namespace ExampleCodeGenApp.ViewModels
 {
     public class CodeGenConnectionViewModel : ConnectionViewModel
     {
-        static CodeGenConnectionViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenConnectionView(), typeof(IViewFor<CodeGenConnectionViewModel>));
-        }
-
         public CodeGenConnectionViewModel(NetworkViewModel parent, NodeInputViewModel input, NodeOutputViewModel output) : base(parent, input, output)
         {
 

--- a/ExampleCodeGenApp/ViewModels/CodeGenNodeViewModel.cs
+++ b/ExampleCodeGenApp/ViewModels/CodeGenNodeViewModel.cs
@@ -17,11 +17,6 @@ namespace ExampleCodeGenApp.ViewModels
 
     public class CodeGenNodeViewModel : NodeViewModel
     {
-        static CodeGenNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenNodeView(), typeof(IViewFor<CodeGenNodeViewModel>));
-        }
-
         public NodeType NodeType { get; }
 
         public CodeGenNodeViewModel(NodeType type)

--- a/ExampleCodeGenApp/ViewModels/CodeGenPendingConnectionViewModel.cs
+++ b/ExampleCodeGenApp/ViewModels/CodeGenPendingConnectionViewModel.cs
@@ -11,11 +11,6 @@ namespace ExampleCodeGenApp.ViewModels
 {
     public class CodeGenPendingConnectionViewModel : PendingConnectionViewModel
     {
-        static CodeGenPendingConnectionViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenPendingConnectionView(), typeof(IViewFor<CodeGenPendingConnectionViewModel>));
-        }
-
         public CodeGenPendingConnectionViewModel(NetworkViewModel parent) : base(parent)
         {
 

--- a/ExampleCodeGenApp/ViewModels/CodeGenPortViewModel.cs
+++ b/ExampleCodeGenApp/ViewModels/CodeGenPortViewModel.cs
@@ -15,11 +15,6 @@ namespace ExampleCodeGenApp.ViewModels
 
     public class CodeGenPortViewModel : PortViewModel
     {
-        static CodeGenPortViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new Views.CodeGenPortView(), typeof(IViewFor<CodeGenPortViewModel>));
-        }
-
         #region PortType
         public PortType PortType
         {

--- a/ExampleCodeGenApp/ViewModels/Editors/IntegerValueEditorViewModel.cs
+++ b/ExampleCodeGenApp/ViewModels/Editors/IntegerValueEditorViewModel.cs
@@ -6,11 +6,6 @@ namespace ExampleCodeGenApp.ViewModels.Editors
 {
     public class IntegerValueEditorViewModel : ValueEditorViewModel<int?>
     {
-        static IntegerValueEditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new IntegerValueEditorView(), typeof(IViewFor<IntegerValueEditorViewModel>));
-        }
-
         public IntegerValueEditorViewModel()
         {
             Value = 0;

--- a/ExampleCodeGenApp/ViewModels/Editors/StringValueEditorViewModel.cs
+++ b/ExampleCodeGenApp/ViewModels/Editors/StringValueEditorViewModel.cs
@@ -6,11 +6,6 @@ namespace ExampleCodeGenApp.ViewModels.Editors
 {
     public class StringValueEditorViewModel : ValueEditorViewModel<string>
     {
-        static StringValueEditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new StringValueEditorView(), typeof(IViewFor<StringValueEditorViewModel>));
-        }
-
         public StringValueEditorViewModel()
         {
             Value = "";

--- a/ExampleCodeGenApp/ViewModels/Nodes/ButtonEventNode.cs
+++ b/ExampleCodeGenApp/ViewModels/Nodes/ButtonEventNode.cs
@@ -14,11 +14,6 @@ namespace ExampleCodeGenApp.ViewModels.Nodes
 {
     public class ButtonEventNode : CodeGenNodeViewModel
     {
-        static ButtonEventNode()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenNodeView(), typeof(IViewFor<ButtonEventNode>));
-        }
-
         public ValueListNodeInputViewModel<IStatement> OnClickFlow { get; }
 
         public ButtonEventNode() : base(NodeType.EventNode)

--- a/ExampleCodeGenApp/ViewModels/Nodes/ForLoopNode.cs
+++ b/ExampleCodeGenApp/ViewModels/Nodes/ForLoopNode.cs
@@ -17,11 +17,6 @@ namespace ExampleCodeGenApp.ViewModels.Nodes
 {
     public class ForLoopNode : CodeGenNodeViewModel
     {
-        static ForLoopNode()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenNodeView(), typeof(IViewFor<ForLoopNode>));
-        }
-
         public ValueNodeOutputViewModel<IStatement> FlowIn { get; }
 
         public ValueListNodeInputViewModel<IStatement> LoopBodyFlow { get; }

--- a/ExampleCodeGenApp/ViewModels/Nodes/IntLiteralNode.cs
+++ b/ExampleCodeGenApp/ViewModels/Nodes/IntLiteralNode.cs
@@ -17,11 +17,6 @@ namespace ExampleCodeGenApp.ViewModels.Nodes
 {
     public class IntLiteralNode : CodeGenNodeViewModel
     {
-        static IntLiteralNode()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenNodeView(), typeof(IViewFor<IntLiteralNode>));
-        }
-
         public IntegerValueEditorViewModel ValueEditor { get; } = new IntegerValueEditorViewModel();
 
         public ValueNodeOutputViewModel<ITypedExpression<int>> Output { get; }

--- a/ExampleCodeGenApp/ViewModels/Nodes/PrintNode.cs
+++ b/ExampleCodeGenApp/ViewModels/Nodes/PrintNode.cs
@@ -16,11 +16,6 @@ namespace ExampleCodeGenApp.ViewModels.Nodes
 {
     public class PrintNode : CodeGenNodeViewModel
     {
-        static PrintNode()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenNodeView(), typeof(IViewFor<PrintNode>));
-        }
-
         public ValueNodeInputViewModel<ITypedExpression<string>> Text { get; }
 
         public ValueNodeOutputViewModel<IStatement> Flow { get; }

--- a/ExampleCodeGenApp/ViewModels/Nodes/TextLiteralNode.cs
+++ b/ExampleCodeGenApp/ViewModels/Nodes/TextLiteralNode.cs
@@ -16,11 +16,6 @@ namespace ExampleCodeGenApp.ViewModels.Nodes
 {
     public class TextLiteralNode : CodeGenNodeViewModel
     {
-        static TextLiteralNode()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new CodeGenNodeView(), typeof(IViewFor<TextLiteralNode>));
-        }
-
         public StringValueEditorViewModel ValueEditor { get; } = new StringValueEditorViewModel();
 
         public ValueNodeOutputViewModel<ITypedExpression<string>> Output { get; }

--- a/ExampleShaderEditorApp/App.xaml.cs
+++ b/ExampleShaderEditorApp/App.xaml.cs
@@ -1,14 +1,49 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
+using ExampleShaderEditorApp.ViewModels;
+using ExampleShaderEditorApp.ViewModels.Editors;
+using ExampleShaderEditorApp.ViewModels.Nodes;
+using ExampleShaderEditorApp.Views;
+using NodeNetwork.Utilities;
+using NodeNetwork.Views;
+using ReactiveUI;
+using Splat;
 
 namespace ExampleShaderEditorApp
 {
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            InitSplatContainer();
+
+            base.OnStartup(e);
+        }
+
+        private void InitSplatContainer()
+        {
+            var container = Locator.CurrentMutable;
+
+            // Register NodeNetwork components. 
+            container.UseNodeNetwork();
+            
+            // Register custom components. 
+            container.Register(() => new ColorEditorView(), typeof(IViewFor<ColorEditorViewModel>));
+            container.Register(() => new FloatEditorView(), typeof(IViewFor<FloatEditorViewModel>));
+            container.Register(() => new Vec2EditorView(), typeof(ReactiveUI.IViewFor<Vec2EditorViewModel>));
+            container.Register(() => new Vec3EditorView(), typeof(ReactiveUI.IViewFor<Vec3EditorViewModel>));
+            container.Register(() => new EnumEditorView(), typeof(IViewFor<EnumEditorViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<ColorNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<GeometryNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<Math2NodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<MathNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<ShaderOutputNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<Vec2PackNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<Vec2UnpackNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<Vec3MathNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<Vec3PackNodeViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<Vec3UnpackNodeViewModel>));
+            container.Register(() => new NodeInputView(), typeof(IViewFor<ShaderNodeInputViewModel>));
+            container.Register(() => new NodeOutputView(), typeof(IViewFor<ShaderNodeOutputViewModel>));
+        }
     }
 }

--- a/ExampleShaderEditorApp/ViewModels/Editors/ColorEditorViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Editors/ColorEditorViewModel.cs
@@ -10,11 +10,6 @@ namespace ExampleShaderEditorApp.ViewModels.Editors
 {
     public class ColorEditorViewModel : ValueEditorViewModel<ShaderFunc>
     {
-        static ColorEditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new ColorEditorView(), typeof(IViewFor<ColorEditorViewModel>));
-        }
-        
         #region ColorValue
         private Color _colorValue;
         public Color ColorValue

--- a/ExampleShaderEditorApp/ViewModels/Editors/FloatEditorViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Editors/FloatEditorViewModel.cs
@@ -14,11 +14,6 @@ namespace ExampleShaderEditorApp.ViewModels.Editors
 {
     public class FloatEditorViewModel : ValueEditorViewModel<ShaderFunc>
     {
-        static FloatEditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new FloatEditorView(), typeof(IViewFor<FloatEditorViewModel>));
-        }
-
         #region FloatValue
         private float _floatValue;
         public float FloatValue

--- a/ExampleShaderEditorApp/ViewModels/Editors/Vec2EditorViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Editors/Vec2EditorViewModel.cs
@@ -14,11 +14,6 @@ namespace ExampleShaderEditorApp.ViewModels.Editors
 {
     public class Vec2EditorViewModel : ValueEditorViewModel<ShaderFunc>
     {
-        static Vec2EditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new Vec2EditorView(), typeof(ReactiveUI.IViewFor<Vec2EditorViewModel>));
-        }
-
         #region Vec2Value
         private Vec2 _vec2Value;
         public Vec2 Vec2Value

--- a/ExampleShaderEditorApp/ViewModels/Editors/Vec3EditorViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Editors/Vec3EditorViewModel.cs
@@ -14,11 +14,6 @@ namespace ExampleShaderEditorApp.ViewModels.Editors
 {
     public class Vec3EditorViewModel : ValueEditorViewModel<ShaderFunc>
     {
-        static Vec3EditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new Vec3EditorView(), typeof(ReactiveUI.IViewFor<Vec3EditorViewModel>));
-        }
-        
         #region Vec3Value
         private Vec3 _vec3Value;
         public Vec3 Vec3Value

--- a/ExampleShaderEditorApp/ViewModels/EnumEditorViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/EnumEditorViewModel.cs
@@ -12,11 +12,6 @@ namespace ExampleShaderEditorApp.ViewModels
 {
     public class EnumEditorViewModel : ValueEditorViewModel<object>
     {
-        static EnumEditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new EnumEditorView(), typeof(IViewFor<EnumEditorViewModel>));
-        }
-
         public object[] Options { get; }
         public string[] OptionLabels { get; }
         

--- a/ExampleShaderEditorApp/ViewModels/Nodes/ColorNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/ColorNodeViewModel.cs
@@ -18,11 +18,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class ColorNodeViewModel : ShaderNodeViewModel
     {
-        static ColorNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<ColorNodeViewModel>));
-        }
-
         public ShaderNodeOutputViewModel ColorOutput { get; } = new ShaderNodeOutputViewModel();
 
         

--- a/ExampleShaderEditorApp/ViewModels/Nodes/GeometryNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/GeometryNodeViewModel.cs
@@ -15,11 +15,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class GeometryNodeViewModel : ShaderNodeViewModel
     {
-        static GeometryNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<GeometryNodeViewModel>));
-        }
-
         public ShaderNodeOutputViewModel VertexPositionOutput { get; } = new ShaderNodeOutputViewModel();
         public ShaderNodeOutputViewModel NormalOutput { get; } = new ShaderNodeOutputViewModel();
         public ShaderNodeOutputViewModel CameraOutput { get; } = new ShaderNodeOutputViewModel();

--- a/ExampleShaderEditorApp/ViewModels/Nodes/Math2NodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/Math2NodeViewModel.cs
@@ -16,11 +16,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class Math2NodeViewModel : ShaderNodeViewModel
     {
-        static Math2NodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<Math2NodeViewModel>));
-        }
-
         public enum MathOperation
         {
             Add,

--- a/ExampleShaderEditorApp/ViewModels/Nodes/MathNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/MathNodeViewModel.cs
@@ -16,11 +16,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class MathNodeViewModel : ShaderNodeViewModel
     {
-        static MathNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<MathNodeViewModel>));
-        }
-
         public enum MathOperation
         {
             Sine,

--- a/ExampleShaderEditorApp/ViewModels/Nodes/ShaderOutputNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/ShaderOutputNodeViewModel.cs
@@ -15,11 +15,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class ShaderOutputNodeViewModel : ShaderNodeViewModel
     {
-        static ShaderOutputNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<ShaderOutputNodeViewModel>));
-        }
-
         public ShaderNodeInputViewModel ColorInput { get; } = new ShaderNodeInputViewModel(typeof(Vec3));
 
         public ShaderOutputNodeViewModel()

--- a/ExampleShaderEditorApp/ViewModels/Nodes/Vec2PackNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/Vec2PackNodeViewModel.cs
@@ -15,11 +15,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class Vec2PackNodeViewModel : ShaderNodeViewModel
     {
-        static Vec2PackNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<Vec2PackNodeViewModel>));
-        }
-
         public ShaderNodeInputViewModel XInput { get; } = new ShaderNodeInputViewModel(typeof(float));
         public ShaderNodeInputViewModel YInput { get; } = new ShaderNodeInputViewModel(typeof(float));
 

--- a/ExampleShaderEditorApp/ViewModels/Nodes/Vec2UnpackNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/Vec2UnpackNodeViewModel.cs
@@ -15,11 +15,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class Vec2UnpackNodeViewModel : ShaderNodeViewModel
     {
-        static Vec2UnpackNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<Vec2UnpackNodeViewModel>));
-        }
-
         public ShaderNodeInputViewModel VectorInput { get; } = new ShaderNodeInputViewModel(typeof(Vec2));
 
         public ShaderNodeOutputViewModel X { get; } = new ShaderNodeOutputViewModel();

--- a/ExampleShaderEditorApp/ViewModels/Nodes/Vec3MathNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/Vec3MathNodeViewModel.cs
@@ -16,11 +16,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class Vec3MathNodeViewModel : ShaderNodeViewModel
     {
-        static Vec3MathNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<Vec3MathNodeViewModel>));
-        }
-
         enum MathOperation
         {
             Add, Subtract, Multiply, Divide, CrossProduct, DotProduct, Distance, Reflect, Min, Max

--- a/ExampleShaderEditorApp/ViewModels/Nodes/Vec3PackNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/Vec3PackNodeViewModel.cs
@@ -15,11 +15,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class Vec3PackNodeViewModel : ShaderNodeViewModel
     {
-        static Vec3PackNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<Vec3PackNodeViewModel>));
-        }
-
         public ShaderNodeInputViewModel XInput { get; } = new ShaderNodeInputViewModel(typeof(float));
         public ShaderNodeInputViewModel YInput { get; } = new ShaderNodeInputViewModel(typeof(float));
         public ShaderNodeInputViewModel ZInput { get; } = new ShaderNodeInputViewModel(typeof(float));

--- a/ExampleShaderEditorApp/ViewModels/Nodes/Vec3UnpackNodeViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/Nodes/Vec3UnpackNodeViewModel.cs
@@ -15,11 +15,6 @@ namespace ExampleShaderEditorApp.ViewModels.Nodes
 {
     public class Vec3UnpackNodeViewModel : ShaderNodeViewModel
     {
-        static Vec3UnpackNodeViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<Vec3UnpackNodeViewModel>));
-        }
-
         public ShaderNodeInputViewModel VectorInput { get; } = new ShaderNodeInputViewModel(typeof(Vec3));
 
         public ShaderNodeOutputViewModel X { get; } = new ShaderNodeOutputViewModel();

--- a/ExampleShaderEditorApp/ViewModels/ShaderNodeInputViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/ShaderNodeInputViewModel.cs
@@ -12,11 +12,6 @@ namespace ExampleShaderEditorApp.ViewModels
 {
     public class ShaderNodeInputViewModel : ValueNodeInputViewModel<ShaderFunc>
     {
-        static ShaderNodeInputViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeInputView(), typeof(IViewFor<ShaderNodeInputViewModel>));
-        }
-
         public ShaderNodeInputViewModel(params Type[] acceptedTypes)
         {
             Editor = null;

--- a/ExampleShaderEditorApp/ViewModels/ShaderNodeOutputViewModel.cs
+++ b/ExampleShaderEditorApp/ViewModels/ShaderNodeOutputViewModel.cs
@@ -8,11 +8,6 @@ namespace ExampleShaderEditorApp.ViewModels
 {
     public class ShaderNodeOutputViewModel : ValueNodeOutputViewModel<ShaderFunc>
     {
-        static ShaderNodeOutputViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeOutputView(), typeof(IViewFor<ShaderNodeOutputViewModel>));
-        }
-
         public Type ReturnType { get; set; }
     }
 }

--- a/NodeNetwork/Utilities/SplatContainerExtensions.cs
+++ b/NodeNetwork/Utilities/SplatContainerExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NodeNetwork.ViewModels;
+using NodeNetwork.Views;
+using ReactiveUI;
+using Splat;
+
+namespace NodeNetwork.Utilities
+{
+    public static class SplatContainerExtensions
+    {
+        public static IMutableDependencyResolver UseNodeNetwork(this IMutableDependencyResolver container)
+        {
+            container.Register(() => new ConnectionView(), typeof(IViewFor<ConnectionViewModel>));
+            container.Register(() => new ErrorMessageView(), typeof(IViewFor<ErrorMessageViewModel>));
+            container.Register(() => new NetworkView(), typeof(IViewFor<NetworkViewModel>));
+            container.Register(() => new NodeEndpointEditorView(), typeof(IViewFor<NodeEndpointEditorViewModel>));
+            container.Register(() => new NodeInputView(), typeof(IViewFor<NodeInputViewModel>));
+            container.Register(() => new NodeOutputView(), typeof(IViewFor<NodeOutputViewModel>));
+            container.Register(() => new NodeView(), typeof(IViewFor<NodeViewModel>));
+            container.Register(() => new PendingConnectionView(), typeof(IViewFor<PendingConnectionViewModel>));
+            container.Register(() => new PortView(), typeof(IViewFor<PortViewModel>));
+
+            container.RegisterPlatformBitmapLoader();
+
+            return container;
+        }
+    }
+}

--- a/NodeNetwork/ViewModels/ConnectionViewModel.cs
+++ b/NodeNetwork/ViewModels/ConnectionViewModel.cs
@@ -16,11 +16,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class ConnectionViewModel : ReactiveObject
     {
-        static ConnectionViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new ConnectionView(), typeof(IViewFor<ConnectionViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/ErrorMessageViewModel.cs
+++ b/NodeNetwork/ViewModels/ErrorMessageViewModel.cs
@@ -13,11 +13,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class ErrorMessageViewModel : ReactiveObject
     {
-        static ErrorMessageViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new ErrorMessageView(), typeof(IViewFor<ErrorMessageViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/NetworkViewModel.cs
+++ b/NodeNetwork/ViewModels/NetworkViewModel.cs
@@ -23,11 +23,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class NetworkViewModel : ReactiveObject
     {
-        static NetworkViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NetworkView(), typeof(IViewFor<NetworkViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/NodeEndpointEditorViewModel.cs
+++ b/NodeNetwork/ViewModels/NodeEndpointEditorViewModel.cs
@@ -15,11 +15,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class NodeEndpointEditorViewModel : ReactiveObject
     {
-        static NodeEndpointEditorViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeEndpointEditorView(), typeof(IViewFor<NodeEndpointEditorViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/NodeInputViewModel.cs
+++ b/NodeNetwork/ViewModels/NodeInputViewModel.cs
@@ -17,11 +17,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class NodeInputViewModel : Endpoint
     {
-        static NodeInputViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeInputView(), typeof(IViewFor<NodeInputViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/NodeOutputViewModel.cs
+++ b/NodeNetwork/ViewModels/NodeOutputViewModel.cs
@@ -18,11 +18,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class NodeOutputViewModel : Endpoint
     {
-        static NodeOutputViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new NodeOutputView(), typeof(IViewFor<NodeOutputViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/NodeViewModel.cs
+++ b/NodeNetwork/ViewModels/NodeViewModel.cs
@@ -21,12 +21,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class NodeViewModel : ReactiveObject
     {
-        static NodeViewModel()
-        {
-            Locator.CurrentMutable.Register(() => new NodeView(), typeof(IViewFor<NodeViewModel>));
-            Locator.CurrentMutable.RegisterPlatformBitmapLoader();
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/PendingConnectionViewModel.cs
+++ b/NodeNetwork/ViewModels/PendingConnectionViewModel.cs
@@ -15,11 +15,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class PendingConnectionViewModel : ReactiveObject
     {
-        static PendingConnectionViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new PendingConnectionView(), typeof(IViewFor<PendingConnectionViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion

--- a/NodeNetwork/ViewModels/PortViewModel.cs
+++ b/NodeNetwork/ViewModels/PortViewModel.cs
@@ -16,11 +16,6 @@ namespace NodeNetwork.ViewModels
     /// </summary>
     public class PortViewModel : ReactiveObject
     {
-        static PortViewModel()
-        {
-            Splat.Locator.CurrentMutable.Register(() => new PortView(), typeof(IViewFor<PortViewModel>));
-        }
-
         #region Logger
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion


### PR DESCRIPTION
## Intro
Thank you for building such an awesome library for node networks! I am currently evaluating your library for my application. Sadly I came across the following issue. 

## Issue
The type registrations on the Splat DI-Container from static constructors within the view models will always fail, if the underlying container, for example Microsoft Unity, has already been built. 
Apart from that, imho, the solution via static constructors adds an unnecessary coupling between the view models and the views. 

Sadly, this issue prevents the use of NodeNetwork in applications, where Splat uses an other 3rd party DI-container, like Microsoft Unity, for example, to register and resolve dependencies. 

## Proposed Fix
Move the necessary type registrations for NodeNetwork into an extension method for Splat, which can be used like

```
public partial class App : Application
{
    protected override void OnStartup(StartupEventArgs e)
    {
        InitSplatContainer();

        base.OnStartup(e);
    }

    private void InitSplatContainer()
    {
        var container = Locator.CurrentMutable;
        
        // Register NodeNetwork components. 
        container.UseNodeNetwork();
        
        // Register custom components. 
        container.Register(() => new MainWindow(), typeof(IViewFor<MainViewModel>));
        container.Register(() => new IntegerValueEditorView(), typeof(IViewFor<IntegerValueEditorViewModel>));
        container.Register(() => new NodeView(), typeof(IViewFor<ConstantNodeViewModel>));
        container.Register(() => new NodeView(), typeof(IViewFor<DivisionNodeViewModel>));
        container.Register(() => new NodeView(), typeof(IViewFor<OutputNodeViewModel>));
        container.Register(() => new NodeView(), typeof(IViewFor<ProductNodeViewModel>));
        container.Register(() => new NodeView(), typeof(IViewFor<SubtractionNodeViewModel>));
        container.Register(() => new NodeView(), typeof(IViewFor<SumNodeViewModel>));
    }
}
```

The extension method "UseNodeNetwork()" is defined as follows

```
public static class SplatContainerExtensions
{
    public static IMutableDependencyResolver UseNodeNetwork(this IMutableDependencyResolver container)
    {
        container.Register(() => new ConnectionView(), typeof(IViewFor<ConnectionViewModel>));
        container.Register(() => new ErrorMessageView(), typeof(IViewFor<ErrorMessageViewModel>));
        container.Register(() => new NetworkView(), typeof(IViewFor<NetworkViewModel>));
        container.Register(() => new NodeEndpointEditorView(), typeof(IViewFor<NodeEndpointEditorViewModel>));
        container.Register(() => new NodeInputView(), typeof(IViewFor<NodeInputViewModel>));
        container.Register(() => new NodeOutputView(), typeof(IViewFor<NodeOutputViewModel>));
        container.Register(() => new NodeView(), typeof(IViewFor<NodeViewModel>));
        container.Register(() => new PendingConnectionView(), typeof(IViewFor<PendingConnectionViewModel>));
        container.Register(() => new PortView(), typeof(IViewFor<PortViewModel>));

        container.RegisterPlatformBitmapLoader();

        return container;
    }
}
```

## Pull-Request
This pull-request removes all type registrations via static constructor from the view models, except for generic view models (how do you register them in Splat?). Instead, it uses the proposed extension method for the Splat DI-container to add the necessary registrations. 
I've also adapted all example apps to use this strategy. 