### PR TITLE
Added prism example app with custom SplatteredPrismViewLocator

### DIFF
--- a/ExampleCodeGenPrismApp/App.xaml
+++ b/ExampleCodeGenPrismApp/App.xaml
@@ -1,0 +1,9 @@
+﻿<unity:PrismApplication x:Class="ExampleCodeGenApp.App"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:local="clr-namespace:ExampleCodeGenApp"
+                  xmlns:unity="http://prismlibrary.com/">
+    <Application.Resources>
+         
+    </Application.Resources>
+</unity:PrismApplication>

--- a/ExampleCodeGenPrismApp/App.xaml.cs
+++ b/ExampleCodeGenPrismApp/App.xaml.cs
@@ -1,0 +1,63 @@
+﻿using System.Windows;
+using ExampleCodeGenApp.ViewModels;
+using ExampleCodeGenApp.ViewModels.Editors;
+using ExampleCodeGenApp.ViewModels.Nodes;
+using ExampleCodeGenApp.Views;
+using ExampleCodeGenApp.Views.Editors;
+using ExampleCodeGenPrismApp.Infrastructure;
+using NodeNetwork.ViewModels;
+using NodeNetwork.Views;
+using Prism.Ioc;
+using Prism.Mvvm;
+using Prism.Unity;
+
+namespace ExampleCodeGenApp
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : PrismApplication
+    {
+        protected override void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+            var splatteredRegistry = Container.UseSplatteredPrismViewLocator();
+
+            // Splat/ReactiveUI resolve Views from View Models
+            // Register Node Network Elements
+            splatteredRegistry.Register(typeof(ConnectionView), typeof(ConnectionViewModel));
+            splatteredRegistry.Register(typeof(ErrorMessageView), typeof(ErrorMessageViewModel));
+            splatteredRegistry.Register(typeof(NetworkView), typeof(NetworkViewModel));
+            splatteredRegistry.Register(typeof(NodeEndpointEditorView), typeof(NodeEndpointEditorViewModel));
+            splatteredRegistry.Register(typeof(NodeInputView), typeof(NodeInputViewModel));
+            splatteredRegistry.Register(typeof(NodeOutputView), typeof(NodeOutputViewModel));
+            splatteredRegistry.Register(typeof(NodeView), typeof(NodeViewModel));
+            splatteredRegistry.Register(typeof(PendingConnectionView), typeof(PendingConnectionViewModel));
+            splatteredRegistry.Register(typeof(PortView), typeof(PortViewModel));
+
+            // Register custom Node Network Elements
+            splatteredRegistry.Register(typeof(CodeGenConnectionView), typeof(CodeGenConnectionViewModel));
+            splatteredRegistry.Register(typeof(NodeInputView), typeof(CodeGenInputViewModel<>));
+            splatteredRegistry.Register(typeof(NodeInputView), typeof(CodeGenListInputViewModel<>));
+            splatteredRegistry.Register(typeof(CodeGenNodeView), typeof(CodeGenNodeViewModel));
+            splatteredRegistry.Register(typeof(NodeOutputView), typeof(CodeGenOutputViewModel<>));
+            splatteredRegistry.Register(typeof(CodeGenPendingConnectionView), typeof(CodeGenPendingConnectionViewModel));
+            splatteredRegistry.Register(typeof(CodeGenPortView), typeof(CodeGenPortViewModel));
+            splatteredRegistry.Register(typeof(IntegerValueEditorView), typeof(IntegerValueEditorViewModel));
+            splatteredRegistry.Register(typeof(StringValueEditorView), typeof(StringValueEditorViewModel));
+            splatteredRegistry.Register(typeof(CodeGenNodeView), typeof(ButtonEventNode));
+            splatteredRegistry.Register(typeof(CodeGenNodeView), typeof(ForLoopNode));
+            splatteredRegistry.Register(typeof(CodeGenNodeView), typeof(IntLiteralNode));
+            splatteredRegistry.Register(typeof(CodeGenNodeView), typeof(PrintNode));
+            splatteredRegistry.Register(typeof(CodeGenNodeView), typeof(TextLiteralNode));
+
+            // Prism resolves View Models from Views
+            // Explicit registration required, because naming convention not followed. 
+            ViewModelLocationProvider.Register<MainWindow, MainViewModel>();
+        }
+
+        protected override Window CreateShell()
+        {
+            return Container.Resolve<MainWindow>();
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ExampleCodeGenPrismApp.csproj
+++ b/ExampleCodeGenPrismApp/ExampleCodeGenPrismApp.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <StartupObject>ExampleCodeGenApp.App</StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.Windows" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NodeNetworkToolkit\NodeNetworkToolkit.csproj" />
+    <ProjectReference Include="..\NodeNetwork\NodeNetwork.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.7.0" />
+    <PackageReference Include="MoonSharp" Version="2.0.0.0" />
+    <PackageReference Include="Prism.Unity" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Wpf" Version="7.2.0.1422" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/ExampleCodeGenPrismApp/Infrastructure/ISplatteredRegistry.cs
+++ b/ExampleCodeGenPrismApp/Infrastructure/ISplatteredRegistry.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using ReactiveUI;
+
+namespace ExampleCodeGenPrismApp.Infrastructure
+{
+    public interface ISplatteredRegistry
+    {
+        void Register<TView, TViewModel>() where TView : class, IViewFor;
+        void Register(Type viewType, Type viewModelType);
+    }
+}

--- a/ExampleCodeGenPrismApp/Infrastructure/SplatteredPrismViewLocator.cs
+++ b/ExampleCodeGenPrismApp/Infrastructure/SplatteredPrismViewLocator.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Ioc;
+using ReactiveUI;
+
+namespace ExampleCodeGenPrismApp.Infrastructure
+{
+    public class SplatteredPrismViewLocator : IViewLocator, ISplatteredRegistry
+    {
+        private readonly IDictionary<Type, Type> _viewMap;
+        
+        public IContainerProvider Container { get; set; }
+
+        private static SplatteredPrismViewLocator _instance;
+        public static SplatteredPrismViewLocator Current
+        {
+            get { return _instance ??= new SplatteredPrismViewLocator(); }
+        }
+
+        private SplatteredPrismViewLocator()
+        {
+            _viewMap = new Dictionary<Type, Type>();
+        }
+
+        public IViewFor ResolveView<T>(T viewModel, string contract = null) where T : class
+        {
+            var viewModelType = viewModel.GetType();
+
+            if (_viewMap.ContainsKey(viewModelType))
+                return ResolveFromContainer(_viewMap[viewModelType]);
+
+            if (viewModelType.IsGenericType)
+            {
+                var genericViewModelType = viewModelType.GetGenericTypeDefinition();
+
+                if (_viewMap.ContainsKey(genericViewModelType))
+                    return ResolveFromContainer(_viewMap[genericViewModelType]);
+            }
+
+            return null;
+        }
+
+        private IViewFor ResolveFromContainer(Type viewType)
+        {
+            return Container.Resolve(viewType) as IViewFor;
+        }
+
+        public void Register<TView, TViewModel>() where TView : class, IViewFor
+        {
+            var viewType = typeof(TView);
+            var viewModelType = typeof(TViewModel);
+
+            Register(viewType, viewModelType);
+        }
+
+        public void Register(Type viewType, Type viewModelType)
+        {
+            if (!_viewMap.ContainsKey(viewModelType))
+                _viewMap.Add(viewModelType, viewType);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Infrastructure/SplatteredPrismViewLocatorExtensions.cs
+++ b/ExampleCodeGenPrismApp/Infrastructure/SplatteredPrismViewLocatorExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Prism.Ioc;
+using ReactiveUI;
+using Splat;
+
+namespace ExampleCodeGenPrismApp.Infrastructure
+{
+    public static class SplatteredPrismViewLocatorExtensions
+    {
+        public static ISplatteredRegistry UseSplatteredPrismViewLocator(this IContainerProvider container)
+        {
+            var splatteredLocator = SplatteredPrismViewLocator.Current;
+            splatteredLocator.Container = container;
+
+            // Override the default ViewLocator
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+            Locator.CurrentMutable.RegisterLazySingleton(() => splatteredLocator, typeof(IViewLocator));
+
+            return splatteredLocator;
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/Compiler/CompilerContext.cs
+++ b/ExampleCodeGenPrismApp/Model/Compiler/CompilerContext.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExampleCodeGenApp.Model.Compiler
+{
+    public class ScopeDefinition
+    {
+        public string Identifier { get; }
+
+        public List<IVariableDefinition> Variables { get; } = new List<IVariableDefinition>();
+
+        public ScopeDefinition(string identifier)
+        {
+            Identifier = identifier;
+        }
+    }
+
+    public class CompilerContext
+    {
+        public Stack<ScopeDefinition> VariablesScopesStack { get; } = new Stack<ScopeDefinition>();
+        
+        public string FindFreeVariableName()
+        {
+            return "v" + VariablesScopesStack.SelectMany(s => s.Variables).Count();
+        }
+
+        public void AddVariableToCurrentScope(IVariableDefinition variable)
+        {
+            VariablesScopesStack.Peek().Variables.Add(variable);
+        }
+
+        public void EnterNewScope(string scopeIdentifier)
+        {
+            VariablesScopesStack.Push(new ScopeDefinition(scopeIdentifier));
+        }
+
+        public void LeaveScope()
+        {
+            VariablesScopesStack.Pop();
+        }
+
+        public bool IsInScope(IVariableDefinition variable)
+        {
+            if (variable == null)
+            {
+                return false;
+            }
+
+            return VariablesScopesStack.Any(s => s.Variables.Contains(variable));
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/Compiler/Error/CompilerException.cs
+++ b/ExampleCodeGenPrismApp/Model/Compiler/Error/CompilerException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExampleCodeGenApp.Model.Compiler.Error
+{
+    public class CompilerException : Exception
+    {
+        public CompilerException(string msg) : base(msg)
+        { }
+
+        public CompilerException(string msg, Exception inner) : base(msg, inner)
+        { }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/Compiler/Error/VariableOutOfScopeException.cs
+++ b/ExampleCodeGenPrismApp/Model/Compiler/Error/VariableOutOfScopeException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExampleCodeGenApp.Model.Compiler.Error
+{
+    public class VariableOutOfScopeException : CompilerException
+    {
+        public string VariableName { get; }
+
+        public VariableOutOfScopeException(string variableName) 
+            : base($"The variable '{variableName}' was referenced outside its scope.")
+        {
+            VariableName = variableName;
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/Compiler/IStatement.cs
+++ b/ExampleCodeGenPrismApp/Model/Compiler/IStatement.cs
@@ -1,0 +1,7 @@
+﻿namespace ExampleCodeGenApp.Model.Compiler
+{
+    public interface IStatement
+    {
+        string Compile(CompilerContext context);
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/Compiler/ITypedExpression.cs
+++ b/ExampleCodeGenPrismApp/Model/Compiler/ITypedExpression.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExampleCodeGenApp.Model.Compiler
+{
+    public interface IExpression
+    {
+        string Compile(CompilerContext context);
+    }
+
+    public interface ITypedExpression<T> : IExpression
+    {
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/ForLoop.cs
+++ b/ExampleCodeGenPrismApp/Model/ForLoop.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class ForLoop : IStatement
+    {
+        public IStatement LoopBody { get; set; }
+        public IStatement LoopEnd { get; set; }
+
+        public ITypedExpression<int> LowerBound { get; set; }
+        public ITypedExpression<int> UpperBound { get; set; }
+
+        public InlineVariableDefinition<int> CurrentIndex { get; } = new InlineVariableDefinition<int>();
+
+        public string Compile(CompilerContext context)
+        {
+            context.EnterNewScope("For loop");
+
+            CurrentIndex.Value = LowerBound;
+            string code = $"for {CurrentIndex.Compile(context)}, {UpperBound.Compile(context)} do\n" +
+                   LoopBody.Compile(context) + "\n" +
+                   $"end\n" +
+                   LoopEnd.Compile(context) + "\n";
+
+            context.LeaveScope();
+            return code;
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/FunctionCall.cs
+++ b/ExampleCodeGenPrismApp/Model/FunctionCall.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class FunctionCall : IStatement
+    {
+        public string FunctionName { get; set; }
+        public List<IExpression> Parameters { get; } = new List<IExpression>();
+
+        public string Compile(CompilerContext context)
+        {
+            return $"{FunctionName}({String.Join(", ", Parameters.Select(p => p.Compile(context)))})\n";
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/ITypedVariableDefinition.cs
+++ b/ExampleCodeGenPrismApp/Model/ITypedVariableDefinition.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public interface IVariableDefinition : IStatement
+    {
+        string VariableName { get; }
+    }
+
+    public interface ITypedVariableDefinition<T> : IVariableDefinition
+    {
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/InlineVariableDefinition.cs
+++ b/ExampleCodeGenPrismApp/Model/InlineVariableDefinition.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class InlineVariableDefinition<T> : ITypedVariableDefinition<T>
+    {
+        public string VariableName { get; private set; }
+        public ITypedExpression<T> Value { get; set; }
+
+        public string Compile(CompilerContext context)
+        {
+            VariableName = context.FindFreeVariableName();
+            context.AddVariableToCurrentScope(this);
+            return $"{VariableName} = {Value.Compile(context)}";
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/IntLiteral.cs
+++ b/ExampleCodeGenPrismApp/Model/IntLiteral.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class IntLiteral : ITypedExpression<int>
+    {
+        public int Value { get; set; }
+
+        public string Compile(CompilerContext context)
+        {
+            return Value.ToString();
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/LocalVariableDefinition.cs
+++ b/ExampleCodeGenPrismApp/Model/LocalVariableDefinition.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class LocalVariableDefinition<T> : ITypedVariableDefinition<T>
+    {
+        public string VariableName { get; private set; }
+        public string Value { get; set; }
+
+        public string Compile(CompilerContext context)
+        {
+            VariableName = context.FindFreeVariableName();
+            context.AddVariableToCurrentScope(this);
+            return $"local {VariableName} = {Value}\n";
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/StatementSequence.cs
+++ b/ExampleCodeGenPrismApp/Model/StatementSequence.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class StatementSequence : IStatement
+    {
+        public List<IStatement> Statements { get; } = new List<IStatement>();
+
+        public StatementSequence()
+        {}
+
+        public StatementSequence(IEnumerable<IStatement> statements)
+        {
+            Statements.AddRange(statements);
+        }
+
+        public string Compile(CompilerContext context)
+        {
+            string result = "";
+            foreach (IStatement statement in Statements)
+            {
+                result += statement.Compile(context);
+                result += "\n";
+            }
+            return result;
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/StringLiteral.cs
+++ b/ExampleCodeGenPrismApp/Model/StringLiteral.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class StringLiteral : ITypedExpression<string>
+    {
+        public string Value { get; set; }
+
+        public string Compile(CompilerContext ctx)
+        {
+            return $"\"{Value}\"";
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/StubStatement.cs
+++ b/ExampleCodeGenPrismApp/Model/StubStatement.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class StubStatement : IStatement
+    {
+        public string Compile(CompilerContext context)
+        {
+            return "";
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Model/VariableReference.cs
+++ b/ExampleCodeGenPrismApp/Model/VariableReference.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+using ExampleCodeGenApp.Model.Compiler.Error;
+
+namespace ExampleCodeGenApp.Model
+{
+    public class VariableReference<T> : ITypedExpression<T>
+    {
+        public ITypedVariableDefinition<T> LocalVariable { get; set; }
+
+        public string Compile(CompilerContext context)
+        {
+            if (!context.IsInScope(LocalVariable))
+            {
+                throw new VariableOutOfScopeException(LocalVariable.VariableName);
+            }
+            return LocalVariable.VariableName;
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Properties/AssemblyInfo.cs
+++ b/ExampleCodeGenPrismApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,55 @@
+﻿using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ExampleCodeGenApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NodeNetwork")]
+[assembly: AssemblyCopyright("Copyright (c) Wouter De Keersmaecker")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+//In order to begin building localizable applications, set
+//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
+//inside a <PropertyGroup>.  For example, if you are using US english
+//in your source files, set the <UICulture> to en-US.  Then uncomment
+//the NeutralResourceLanguage attribute below.  Update the "en-US" in
+//the line below to match the UICulture setting in the project file.
+
+//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]
+
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ExampleCodeGenPrismApp/ViewModels/CodeGenConnectionViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeGenConnectionViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class CodeGenConnectionViewModel : ConnectionViewModel
+    {
+        public CodeGenConnectionViewModel(NetworkViewModel parent, NodeInputViewModel input, NodeOutputViewModel output) : base(parent, input, output)
+        {
+
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodeGenInputViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeGenInputViewModel.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.Toolkit.ValueNode;
+using NodeNetwork.ViewModels;
+using NodeNetwork.Views;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class CodeGenInputViewModel<T> : ValueNodeInputViewModel<T>
+    {
+        public CodeGenInputViewModel(PortType type)
+        {
+            this.Port = new CodeGenPortViewModel { PortType = type };
+
+            if (type == PortType.Execution)
+            {
+                this.PortPosition = PortPosition.Right;
+            }
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodeGenListInputViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeGenListInputViewModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NodeNetwork.Toolkit.ValueNode;
+using NodeNetwork.ViewModels;
+using NodeNetwork.Views;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class CodeGenListInputViewModel<T> : ValueListNodeInputViewModel<T>
+    {
+        public CodeGenListInputViewModel(PortType type)
+        {
+            this.Port = new CodeGenPortViewModel { PortType = type };
+
+            if (type == PortType.Execution)
+            {
+                this.PortPosition = PortPosition.Right;
+            }
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodeGenNodeViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeGenNodeViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public enum NodeType
+    {
+        EventNode, Function, FlowControl, Literal
+    }
+
+    public class CodeGenNodeViewModel : NodeViewModel
+    {
+        public NodeType NodeType { get; }
+
+        public CodeGenNodeViewModel(NodeType type)
+        {
+            NodeType = type;
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodeGenOutputViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeGenOutputViewModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NodeNetwork.Toolkit.ValueNode;
+using NodeNetwork.ViewModels;
+using NodeNetwork.Views;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class CodeGenOutputViewModel<T> : ValueNodeOutputViewModel<T>
+    {
+        public CodeGenOutputViewModel(PortType type)
+        {
+            this.Port = new CodeGenPortViewModel { PortType = type };
+
+            if (type == PortType.Execution)
+            {
+                this.PortPosition = PortPosition.Left;
+            }
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodeGenPendingConnectionViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeGenPendingConnectionViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class CodeGenPendingConnectionViewModel : PendingConnectionViewModel
+    {
+        public CodeGenPendingConnectionViewModel(NetworkViewModel parent) : base(parent)
+        {
+
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodeGenPortViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeGenPortViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public enum PortType
+    {
+        Execution, Integer, String
+    }
+
+    public class CodeGenPortViewModel : PortViewModel
+    {
+        #region PortType
+        public PortType PortType
+        {
+            get => _portType;
+            set => this.RaiseAndSetIfChanged(ref _portType, value);
+        }
+        private PortType _portType;
+        #endregion
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodePreviewViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodePreviewViewModel.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+using ExampleCodeGenApp.Model.Compiler.Error;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class CodePreviewViewModel : ReactiveObject
+    {
+        #region Code
+        public IStatement Code
+        {
+            get => _code;
+            set => this.RaiseAndSetIfChanged(ref _code, value);
+        }
+        private IStatement _code;
+        #endregion
+
+        #region CompilerError
+        public string CompilerError
+        {
+            get => _compilerError;
+            set => this.RaiseAndSetIfChanged(ref _compilerError, value);
+        }
+        private string _compilerError;
+        #endregion
+
+        #region CompiledCode
+        private readonly ObservableAsPropertyHelper<string> _compiledCode;
+        public string CompiledCode => _compiledCode.Value; 
+        #endregion
+
+        public CodePreviewViewModel()
+        {
+            this.WhenAnyValue(vm => vm.Code).Where(c => c != null)
+                .Select(c =>
+                {
+                    CompilerError = "";
+                    CompilerContext ctx = new CompilerContext();
+
+                    try
+                    {
+                        return c.Compile(ctx);
+                    }
+                    catch (CompilerException e)
+                    {
+                        string trace = string.Join("\n", ctx.VariablesScopesStack.Select(s => s.Identifier));
+                        CompilerError = e.Message + "\nProblem is near:\n"+ trace;
+                        return "";
+                    }
+                })
+                .ToProperty(this, vm => vm.CompiledCode, out _compiledCode);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/CodeSimViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/CodeSimViewModel.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExampleCodeGenApp.Model.Compiler;
+using MoonSharp.Interpreter;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class CodeSimViewModel : ReactiveObject
+    {
+        #region Code
+        public IStatement Code
+        {
+            get => _code;
+            set => this.RaiseAndSetIfChanged(ref _code, value);
+        }
+        private IStatement _code;
+        #endregion
+        
+        #region Output
+        public string Output
+        {
+            get => _output;
+            set => this.RaiseAndSetIfChanged(ref _output, value);
+        }
+        private string _output;
+        #endregion
+
+        public ReactiveCommand<Unit, Unit> RunScript { get; }
+        public ReactiveCommand<Unit, Unit> ClearOutput { get; }
+
+        public CodeSimViewModel()
+        {
+            RunScript = ReactiveCommand.Create(() =>
+                {
+                    Script script = new Script();
+                    script.Globals["print"] = (Action<string>)Print;
+                    string source =  Code.Compile(new CompilerContext());
+                    script.DoString(source);
+                },
+                this.WhenAnyValue(vm => vm.Code).Select(code => code != null));
+
+            ClearOutput = ReactiveCommand.Create(() => { Output = ""; });
+        }
+
+        public void Print(string msg)
+        {
+            Output += msg + "\n";
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/Editors/IntegerValueEditorViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/Editors/IntegerValueEditorViewModel.cs
@@ -1,0 +1,14 @@
+﻿using ExampleCodeGenApp.Views.Editors;
+using NodeNetwork.Toolkit.ValueNode;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels.Editors
+{
+    public class IntegerValueEditorViewModel : ValueEditorViewModel<int?>
+    {
+        public IntegerValueEditorViewModel()
+        {
+            Value = 0;
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/Editors/StringValueEditorViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/Editors/StringValueEditorViewModel.cs
@@ -1,0 +1,14 @@
+﻿using ExampleCodeGenApp.Views.Editors;
+using NodeNetwork.Toolkit.ValueNode;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels.Editors
+{
+    public class StringValueEditorViewModel : ValueEditorViewModel<string>
+    {
+        public StringValueEditorViewModel()
+        {
+            Value = "";
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/MainViewModel.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/MainViewModel.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using DynamicData;
+using ExampleCodeGenApp.Model;
+using ExampleCodeGenApp.ViewModels.Nodes;
+using NodeNetwork.Toolkit.Layout;
+using NodeNetwork.Toolkit.Layout.ForceDirected;
+using NodeNetwork.Toolkit.NodeList;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels
+{
+    public class MainViewModel : ReactiveObject
+    {
+        public NetworkViewModel Network { get; } = new NetworkViewModel();
+        public NodeListViewModel NodeList { get; } = new NodeListViewModel();
+        public CodePreviewViewModel CodePreview { get; } = new CodePreviewViewModel();
+        public CodeSimViewModel CodeSim { get; } = new CodeSimViewModel();
+
+        public ReactiveCommand<Unit, Unit> AutoLayout { get; }
+		public ReactiveCommand<Unit, Unit> StartAutoLayoutLive { get; }
+		public ReactiveCommand<Unit, Unit> StopAutoLayoutLive { get; }
+
+		public MainViewModel()
+        {
+            ButtonEventNode eventNode = new ButtonEventNode {CanBeRemovedByUser = false};
+            Network.Nodes.Add(eventNode);
+
+            //NodeList.AddNodeType(() => new ButtonEventNode());
+            NodeList.AddNodeType(() => new ForLoopNode());
+            NodeList.AddNodeType(() => new IntLiteralNode());
+            NodeList.AddNodeType(() => new PrintNode());
+            NodeList.AddNodeType(() => new TextLiteralNode());
+
+            var codeObservable = eventNode.OnClickFlow.Values.Connect().Select(_ => new StatementSequence(eventNode.OnClickFlow.Values.Items));
+            codeObservable.BindTo(this, vm => vm.CodePreview.Code);
+            codeObservable.BindTo(this, vm => vm.CodeSim.Code);
+
+			ForceDirectedLayouter layouter = new ForceDirectedLayouter();
+			var config = new Configuration
+			{
+				Network = Network,
+			};
+			AutoLayout = ReactiveCommand.Create(() => layouter.Layout(config, 10000));
+			StartAutoLayoutLive = ReactiveCommand.CreateFromObservable(() => 
+				Observable.StartAsync(ct => layouter.LayoutAsync(config, ct)).TakeUntil(StopAutoLayoutLive)
+			);
+			StopAutoLayoutLive = ReactiveCommand.Create(() => { }, StartAutoLayoutLive.IsExecuting);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/Nodes/ButtonEventNode.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/Nodes/ButtonEventNode.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData;
+using ExampleCodeGenApp.Model.Compiler;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.Toolkit.ValueNode;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels.Nodes
+{
+    public class ButtonEventNode : CodeGenNodeViewModel
+    {
+        public ValueListNodeInputViewModel<IStatement> OnClickFlow { get; }
+
+        public ButtonEventNode() : base(NodeType.EventNode)
+        {
+            this.Name = "Button Events";
+
+            OnClickFlow = new CodeGenListInputViewModel<IStatement>(PortType.Execution)
+            {
+                Name = "On Click"
+            };
+
+            this.Inputs.Add(OnClickFlow);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/Nodes/ForLoopNode.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/Nodes/ForLoopNode.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData;
+using ExampleCodeGenApp.Model;
+using ExampleCodeGenApp.Model.Compiler;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.Toolkit.ValueNode;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels.Nodes
+{
+    public class ForLoopNode : CodeGenNodeViewModel
+    {
+        public ValueNodeOutputViewModel<IStatement> FlowIn { get; }
+
+        public ValueListNodeInputViewModel<IStatement> LoopBodyFlow { get; }
+        public ValueListNodeInputViewModel<IStatement> LoopEndFlow { get; }
+        
+        public ValueNodeInputViewModel<ITypedExpression<int>> FirstIndex { get; }
+        public ValueNodeInputViewModel<ITypedExpression<int>> LastIndex { get; }
+
+        public ValueNodeOutputViewModel<ITypedExpression<int>> CurrentIndex { get; }
+
+        public ForLoopNode() : base(NodeType.FlowControl)
+        {
+            this.Name = "For Loop";
+            
+            LoopBodyFlow = new CodeGenListInputViewModel<IStatement>(PortType.Execution)
+            {
+                Name = "Loop Body"
+            };
+            this.Inputs.Add(LoopBodyFlow);
+
+            LoopEndFlow = new CodeGenListInputViewModel<IStatement>(PortType.Execution)
+            {
+                Name = "Loop End"
+            };
+            this.Inputs.Add(LoopEndFlow);
+
+            FirstIndex = new CodeGenInputViewModel<ITypedExpression<int>>(PortType.Integer)
+            {
+                Name = "First Index"
+            };
+            this.Inputs.Add(FirstIndex);
+
+            LastIndex = new CodeGenInputViewModel<ITypedExpression<int>>(PortType.Integer)
+            {
+                Name = "Last Index"
+            };
+            this.Inputs.Add(LastIndex);
+
+            ForLoop value = new ForLoop();
+
+            var loopBodyChanged = LoopBodyFlow.Values.Connect().Select(_ => Unit.Default).StartWith(Unit.Default);
+            var loopEndChanged = LoopEndFlow.Values.Connect().Select(_ => Unit.Default).StartWith(Unit.Default);
+            FlowIn = new CodeGenOutputViewModel<IStatement>(PortType.Execution)
+            {
+                Name = "",
+                Value = Observable.CombineLatest(loopBodyChanged, loopEndChanged, FirstIndex.ValueChanged, LastIndex.ValueChanged,
+                        (bodyChange, endChange, firstI, lastI) => (BodyChange: bodyChange, EndChange: endChange, FirstI: firstI, LastI: lastI))
+                    .Select(v => {
+                        value.LoopBody = new StatementSequence(LoopBodyFlow.Values.Items);
+                        value.LoopEnd = new StatementSequence(LoopEndFlow.Values.Items);
+                        value.LowerBound = v.FirstI ?? new IntLiteral {Value = 0};
+                        value.UpperBound = v.LastI ?? new IntLiteral {Value = 1};
+                        return value; 
+                    })
+            };
+            this.Outputs.Add(FlowIn);
+
+            CurrentIndex = new CodeGenOutputViewModel<ITypedExpression<int>>(PortType.Integer)
+            {
+                Name = "Current Index",
+                Value = Observable.Return(new VariableReference<int>{ LocalVariable = value.CurrentIndex })
+            };
+            this.Outputs.Add(CurrentIndex);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/Nodes/IntLiteralNode.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/Nodes/IntLiteralNode.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData;
+using ExampleCodeGenApp.Model;
+using ExampleCodeGenApp.Model.Compiler;
+using ExampleCodeGenApp.ViewModels.Editors;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.Toolkit.ValueNode;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels.Nodes
+{
+    public class IntLiteralNode : CodeGenNodeViewModel
+    {
+        public IntegerValueEditorViewModel ValueEditor { get; } = new IntegerValueEditorViewModel();
+
+        public ValueNodeOutputViewModel<ITypedExpression<int>> Output { get; }
+
+        public IntLiteralNode() : base(NodeType.Literal)
+        {
+            this.Name = "Integer";
+
+            Output = new CodeGenOutputViewModel<ITypedExpression<int>>(PortType.Integer)
+            {
+                Editor = ValueEditor,
+                Value = ValueEditor.ValueChanged.Select(v => new IntLiteral{Value = v ?? 0})
+            };
+            this.Outputs.Add(Output);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/Nodes/PrintNode.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/Nodes/PrintNode.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData;
+using ExampleCodeGenApp.Model;
+using ExampleCodeGenApp.Model.Compiler;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.Toolkit.ValueNode;
+using NodeNetwork.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels.Nodes
+{
+    public class PrintNode : CodeGenNodeViewModel
+    {
+        public ValueNodeInputViewModel<ITypedExpression<string>> Text { get; }
+
+        public ValueNodeOutputViewModel<IStatement> Flow { get; }
+        
+        public PrintNode() : base(NodeType.Function)
+        {
+            this.Name = "Print";
+
+            Text = new CodeGenInputViewModel<ITypedExpression<string>>(PortType.String)
+            {
+                Name = "Text"
+            };
+            this.Inputs.Add(Text);
+
+            Flow = new CodeGenOutputViewModel<IStatement>(PortType.Execution)
+            {
+                Name = "",
+                Value = this.Text.ValueChanged.Select(stringExpr => new FunctionCall
+                {
+                    FunctionName = "print",
+                    Parameters =
+                    {
+                        stringExpr ?? new StringLiteral{Value = ""}
+                    }
+                })
+            };
+            this.Outputs.Add(Flow);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/ViewModels/Nodes/TextLiteralNode.cs
+++ b/ExampleCodeGenPrismApp/ViewModels/Nodes/TextLiteralNode.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData;
+using ExampleCodeGenApp.Model;
+using ExampleCodeGenApp.Model.Compiler;
+using ExampleCodeGenApp.ViewModels.Editors;
+using ExampleCodeGenApp.Views;
+using NodeNetwork.Toolkit.ValueNode;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.ViewModels.Nodes
+{
+    public class TextLiteralNode : CodeGenNodeViewModel
+    {
+        public StringValueEditorViewModel ValueEditor { get; } = new StringValueEditorViewModel();
+
+        public ValueNodeOutputViewModel<ITypedExpression<string>> Output { get; }
+
+        public TextLiteralNode() : base(NodeType.Literal)
+        {
+            this.Name = "Text";
+
+            Output = new CodeGenOutputViewModel<ITypedExpression<string>>(PortType.String)
+            {
+                Name = "Value",
+                Editor = ValueEditor,
+                Value = ValueEditor.ValueChanged.Select(v => new StringLiteral{ Value = v })
+            };
+            this.Outputs.Add(Output);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/CodeGenConnectionView.xaml
+++ b/ExampleCodeGenPrismApp/Views/CodeGenConnectionView.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.CodeGenConnectionView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.Views"
+             xmlns:views="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <views:ConnectionView x:Name="ConnectionView"/>
+</UserControl>

--- a/ExampleCodeGenPrismApp/Views/CodeGenConnectionView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/CodeGenConnectionView.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using ExampleCodeGenApp.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views
+{
+    public partial class CodeGenConnectionView : IViewFor<CodeGenConnectionViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(CodeGenConnectionViewModel), typeof(CodeGenConnectionView), new PropertyMetadata(null));
+
+        public CodeGenConnectionViewModel ViewModel
+        {
+            get => (CodeGenConnectionViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (CodeGenConnectionViewModel)value;
+        }
+        #endregion
+
+        public CodeGenConnectionView()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d =>
+            {
+                ConnectionView.ViewModel = this.ViewModel;
+                d(Disposable.Create(() => ConnectionView.ViewModel = null));
+            });
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/CodeGenNodeView.xaml
+++ b/ExampleCodeGenPrismApp/Views/CodeGenNodeView.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.CodeGenNodeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.Views"
+             xmlns:views="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <views:NodeView x:Name="NodeView"/>
+</UserControl>
+

--- a/ExampleCodeGenPrismApp/Views/CodeGenNodeView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/CodeGenNodeView.xaml.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using ExampleCodeGenApp.ViewModels;
+using NodeNetwork.Views;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views
+{
+    public partial class CodeGenNodeView : IViewFor<CodeGenNodeViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(CodeGenNodeViewModel), typeof(CodeGenNodeView), new PropertyMetadata(null));
+
+        public CodeGenNodeViewModel ViewModel
+        {
+            get => (CodeGenNodeViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (CodeGenNodeViewModel)value;
+        }
+        #endregion
+
+        public CodeGenNodeView()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d =>
+            {
+                NodeView.ViewModel = this.ViewModel;
+                Disposable.Create(() => NodeView.ViewModel = null).DisposeWith(d);
+
+                this.OneWayBind(ViewModel, vm => vm.NodeType, v => v.NodeView.Background, ConvertNodeTypeToBrush).DisposeWith(d);
+            });
+        }
+
+        private Brush ConvertNodeTypeToBrush(NodeType type)
+        {
+            switch (type)
+            {
+                case NodeType.EventNode: return new SolidColorBrush(Color.FromRgb(0x9b, 0x00, 0x00));
+                case NodeType.FlowControl: return new SolidColorBrush(Color.FromRgb(0x49, 0x49, 0x49));
+                case NodeType.Function: return new SolidColorBrush(Color.FromRgb(0x00, 0x39, 0xcb));
+                case NodeType.Literal: return new SolidColorBrush(Color.FromRgb(0x00, 0x60, 0x0f));
+                default: throw new Exception("Unsupported node type");
+            }
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/CodeGenPendingConnectionView.xaml
+++ b/ExampleCodeGenPrismApp/Views/CodeGenPendingConnectionView.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.CodeGenPendingConnectionView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.Views"
+             xmlns:views="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <views:PendingConnectionView x:Name="PendingConnectionView"/>
+</UserControl>

--- a/ExampleCodeGenPrismApp/Views/CodeGenPendingConnectionView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/CodeGenPendingConnectionView.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using ExampleCodeGenApp.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views
+{
+    public partial class CodeGenPendingConnectionView : IViewFor<CodeGenPendingConnectionViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(CodeGenPendingConnectionViewModel), typeof(CodeGenPendingConnectionView), new PropertyMetadata(null));
+
+        public CodeGenPendingConnectionViewModel ViewModel
+        {
+            get => (CodeGenPendingConnectionViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (CodeGenPendingConnectionViewModel)value;
+        }
+        #endregion
+
+        public CodeGenPendingConnectionView()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d =>
+            {
+                PendingConnectionView.ViewModel = this.ViewModel;
+                d(Disposable.Create(() => PendingConnectionView.ViewModel = null));
+            });
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/CodeGenPortView.xaml
+++ b/ExampleCodeGenPrismApp/Views/CodeGenPortView.xaml
@@ -1,0 +1,39 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.CodeGenPortView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.ViewModels"
+             xmlns:views="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
+             xmlns:local1="clr-namespace:ExampleCodeGenApp.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="100" d:DesignWidth="100">
+    <UserControl.Resources>
+        <ControlTemplate x:Key="{x:Static local1:CodeGenPortView.ExecutionPortTemplateKey}" TargetType="views:PortView">
+            <Viewbox StretchDirection="Both" Stretch="Uniform">
+                <Grid Width="20" Height="20">
+                    <Path Fill="White" Data="M 0 0 L 8 0 L 18 10 L 8 20 L 0 20 Z" HorizontalAlignment="Center"/>
+                </Grid>
+            </Viewbox>
+        </ControlTemplate>
+
+        <ControlTemplate x:Key="{x:Static local1:CodeGenPortView.IntegerPortTemplateKey}" TargetType="views:PortView">
+            <Viewbox StretchDirection="Both" Stretch="Uniform">
+                <Grid Width="20" Height="20">
+                    <Ellipse Fill="#7cb342" HorizontalAlignment="Left" VerticalAlignment="Center" Height="15" Width="15"/>
+                    <Path Fill="#7cb342" Data="M 0 0 L 4 4 L 0 8 Z" HorizontalAlignment="Right" VerticalAlignment="Center" Height="8" Width="4"/>
+                </Grid>
+            </Viewbox>
+        </ControlTemplate>
+
+        <ControlTemplate x:Key="{x:Static local1:CodeGenPortView.StringPortTemplateKey}" TargetType="views:PortView">
+            <Viewbox StretchDirection="Both" Stretch="Uniform">
+                <Grid Width="20" Height="20">
+                    <Ellipse Fill="#ba68c8" HorizontalAlignment="Left" VerticalAlignment="Center" Height="15" Width="15"/>
+                    <Path Fill="#ba68c8" Data="M 0 0 L 4 4 L 0 8 Z" HorizontalAlignment="Right" VerticalAlignment="Center" Height="8" Width="4"/>
+                </Grid>
+            </Viewbox>
+        </ControlTemplate>
+    </UserControl.Resources>
+    <views:PortView x:Name="PortView" RenderTransformOrigin="0.5,0.5"/>
+</UserControl>

--- a/ExampleCodeGenPrismApp/Views/CodeGenPortView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/CodeGenPortView.xaml.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Reactive.Disposables;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using ExampleCodeGenApp.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views
+{
+    public partial class CodeGenPortView : IViewFor<CodeGenPortViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(CodeGenPortViewModel), typeof(CodeGenPortView), new PropertyMetadata(null));
+
+        public CodeGenPortViewModel ViewModel
+        {
+            get => (CodeGenPortViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (CodeGenPortViewModel)value;
+        }
+        #endregion
+
+        #region Template Resource Keys
+        public const String ExecutionPortTemplateKey = "ExecutionPortTemplate";
+        public const String IntegerPortTemplateKey = "IntegerPortTemplate";
+        public const String StringPortTemplateKey = "StringPortTemplate"; 
+        #endregion
+
+        public CodeGenPortView()
+        {
+            InitializeComponent();
+            
+            this.WhenActivated(d =>
+            {
+	            this.WhenAnyValue(v => v.ViewModel).BindTo(this, v => v.PortView.ViewModel).DisposeWith(d);
+
+                this.OneWayBind(ViewModel, vm => vm.PortType, v => v.PortView.Template, GetTemplateFromPortType)
+                    .DisposeWith(d);
+
+                this.OneWayBind(ViewModel, vm => vm.IsMirrored, v => v.PortView.RenderTransform,
+                    isMirrored => new ScaleTransform(isMirrored ? -1.0 : 1.0, 1.0))
+                    .DisposeWith(d);
+            });
+        }
+
+        public ControlTemplate GetTemplateFromPortType(PortType type)
+        {
+            switch (type)
+            {
+                case PortType.Execution: return (ControlTemplate) Resources[ExecutionPortTemplateKey];
+                case PortType.Integer: return (ControlTemplate) Resources[IntegerPortTemplateKey];
+                case PortType.String: return (ControlTemplate) Resources[StringPortTemplateKey];
+                default: throw new Exception("Unsupported port type");
+            }
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/CodePreviewView.xaml
+++ b/ExampleCodeGenPrismApp/Views/CodePreviewView.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.CodePreviewView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid Background="#f1f1f1">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Label Content="Code" HorizontalAlignment="Left" Margin="10,10,0,10" VerticalAlignment="Top" FontSize="18" FontFamily="Segoe UI Semilight"/>
+
+        <Grid Grid.Row="1" Margin="10,0,10,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <TextBlock x:Name="errorTextBlock" Foreground="Red" HorizontalAlignment="Left" VerticalAlignment="Top" TextWrapping="Wrap"/>
+        </Grid>
+
+        <Grid Grid.Row="2" Margin="10,0,10,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <TextBlock x:Name="codeTextBlock" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/ExampleCodeGenPrismApp/Views/CodePreviewView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/CodePreviewView.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using ExampleCodeGenApp.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views
+{
+    public partial class CodePreviewView : IViewFor<CodePreviewViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(CodePreviewViewModel), typeof(CodePreviewView), new PropertyMetadata(null));
+
+        public CodePreviewViewModel ViewModel
+        {
+            get => (CodePreviewViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (CodePreviewViewModel)value;
+        }
+        #endregion
+
+        public CodePreviewView()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d => { 
+                this.OneWayBind(ViewModel, vm => vm.CompiledCode, v => v.codeTextBlock.Text).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.CompilerError, v => v.errorTextBlock.Text).DisposeWith(d);
+            });
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/CodeSimView.xaml
+++ b/ExampleCodeGenPrismApp/Views/CodeSimView.xaml
@@ -1,0 +1,27 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.CodeSimView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid Background="#f1f1f1">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Label Content="Run" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontSize="18" FontFamily="Segoe UI Semilight" Grid.RowSpan="2"/>
+
+        <StackPanel Grid.Row="1" Margin="10,10,10,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Orientation="Horizontal">
+            <Button x:Name="runButton" HorizontalAlignment="Left" Content="Trigger"/>
+            <Button x:Name="clearButton" HorizontalAlignment="Left" Content="Clear output" Margin="10, 0, 0, 0"/>
+        </StackPanel>
+        <Grid Grid.Row="2" Margin="10,10,10,0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <TextBlock x:Name="outputTextBlock"/>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/ExampleCodeGenPrismApp/Views/CodeSimView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/CodeSimView.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using ExampleCodeGenApp.ViewModels;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views
+{
+    public partial class CodeSimView : UserControl, IViewFor<CodeSimViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(CodeSimViewModel), typeof(CodeSimView), new PropertyMetadata(null));
+
+        public CodeSimViewModel ViewModel
+        {
+            get => (CodeSimViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (CodeSimViewModel)value;
+        }
+        #endregion
+
+        public CodeSimView()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d =>
+            {
+                this.OneWayBind(ViewModel, vm => vm.RunScript, v => v.runButton.Command).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.ClearOutput, v => v.clearButton.Command).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.Output, v => v.outputTextBlock.Text).DisposeWith(d);
+            });
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/Editors/IntegerValueEditorView.xaml
+++ b/ExampleCodeGenPrismApp/Views/Editors/IntegerValueEditorView.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.Editors.IntegerValueEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.Views"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <xctk:IntegerUpDown Name="UpDown"/>
+</UserControl>

--- a/ExampleCodeGenPrismApp/Views/Editors/IntegerValueEditorView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/Editors/IntegerValueEditorView.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System.Windows;
+using ExampleCodeGenApp.ViewModels;
+using ExampleCodeGenApp.ViewModels.Editors;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views.Editors
+{
+    public partial class IntegerValueEditorView : IViewFor<IntegerValueEditorViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(IntegerValueEditorViewModel), typeof(IntegerValueEditorView), new PropertyMetadata(null));
+
+        public IntegerValueEditorViewModel ViewModel
+        {
+            get => (IntegerValueEditorViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (IntegerValueEditorViewModel)value;
+        }
+        #endregion
+
+        public IntegerValueEditorView()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d => d(
+                this.Bind(ViewModel, vm => vm.Value, v => v.UpDown.Value)
+            ));
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/Editors/StringValueEditorView.xaml
+++ b/ExampleCodeGenPrismApp/Views/Editors/StringValueEditorView.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="ExampleCodeGenApp.Views.Editors.StringValueEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExampleCodeGenApp.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <TextBox x:Name="TextBox" MinWidth="100"/>
+</UserControl>

--- a/ExampleCodeGenPrismApp/Views/Editors/StringValueEditorView.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/Editors/StringValueEditorView.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System.Windows;
+using ExampleCodeGenApp.ViewModels;
+using ExampleCodeGenApp.ViewModels.Editors;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views.Editors
+{
+    public partial class StringValueEditorView : IViewFor<StringValueEditorViewModel>
+    {
+        #region ViewModel
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(nameof(ViewModel),
+            typeof(StringValueEditorViewModel), typeof(StringValueEditorView), new PropertyMetadata(null));
+
+        public StringValueEditorViewModel ViewModel
+        {
+            get => (StringValueEditorViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (StringValueEditorViewModel)value;
+        }
+        #endregion
+
+        public StringValueEditorView()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d => d(
+                this.Bind(ViewModel, vm => vm.Value, v => v.TextBox.Text)
+            ));
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/MainWindow.xaml
+++ b/ExampleCodeGenPrismApp/Views/MainWindow.xaml
@@ -1,0 +1,45 @@
+﻿<views2:WindowViewBase x:TypeArguments="viewModels:MainViewModel" x:Class="ExampleCodeGenApp.Views.MainWindow"
+                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                       xmlns:local="clr-namespace:ExampleCodeGenApp"
+                       xmlns:views="clr-namespace:NodeNetwork.Views;assembly=NodeNetwork"
+                       xmlns:nodeList="clr-namespace:NodeNetwork.Toolkit.NodeList;assembly=NodeNetworkToolkit"
+                       xmlns:views1="clr-namespace:ExampleCodeGenApp.Views"
+                       xmlns:views2="clr-namespace:ExampleCodeGenPrismApp.Views"
+                       xmlns:viewModels="clr-namespace:ExampleCodeGenApp.ViewModels"
+                       xmlns:prism="http://prismlibrary.com/"
+                       mc:Ignorable="d" prism:ViewModelLocator.AutoWireViewModel="True"
+                       Title="MainWindow" Height="350" Width="525">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200"/>
+            <ColumnDefinition Width="5"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="5"/>
+            <ColumnDefinition Width="200"/>
+        </Grid.ColumnDefinitions>
+        <Grid Grid.Column="0">
+            <nodeList:NodeListView x:Name="nodeList" Margin="0,0,0,36"/>
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Margin="10, 0, 10, 8">
+                <Button Name="autoLayoutButton">Auto-layout</Button>
+                <Button Name="startAutoLayoutLiveButton" Margin="0, 5, 0, 0">Start live auto-layout</Button>
+                <Button Name="stopAutoLayoutLiveButton" Margin="0, 5, 0, 0">Stop live auto-layout</Button>
+            </StackPanel>
+        </Grid>
+        <GridSplitter Grid.Column="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
+        <views:NetworkView x:Name="network" Grid.Column="2"/>
+        <GridSplitter Grid.Column="3" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
+        <Grid Grid.Column="4">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="5"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <views1:CodePreviewView Grid.Row="0" x:Name="codePreviewView"/>
+            <GridSplitter Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
+            <views1:CodeSimView Grid.Row="2" x:Name="codeSimView"/>
+        </Grid>
+    </Grid>
+</views2:WindowViewBase>

--- a/ExampleCodeGenPrismApp/Views/MainWindow.xaml.cs
+++ b/ExampleCodeGenPrismApp/Views/MainWindow.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Windows;
+using ExampleCodeGenApp.ViewModels;
+using ExampleCodeGenPrismApp.Views;
+using ReactiveUI;
+
+namespace ExampleCodeGenApp.Views
+{
+    public partial class MainWindow : WindowViewBase<MainViewModel>
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+
+            this.WhenActivated(d =>
+            {
+                this.OneWayBind(ViewModel, vm => vm.Network, v => v.network.ViewModel).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.NodeList, v => v.nodeList.ViewModel).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.CodePreview, v => v.codePreviewView.ViewModel).DisposeWith(d);
+                this.OneWayBind(ViewModel, vm => vm.CodeSim, v => v.codeSimView.ViewModel).DisposeWith(d);
+
+                this.BindCommand(ViewModel, vm => vm.AutoLayout, v => v.autoLayoutButton);
+
+                this.BindCommand(ViewModel, vm => vm.StartAutoLayoutLive, v => v.startAutoLayoutLiveButton);
+                this.WhenAnyObservable(v => v.ViewModel.StartAutoLayoutLive.IsExecuting)
+	                .Select((isRunning) => isRunning ? Visibility.Collapsed : Visibility.Visible)
+	                .BindTo(this, v => v.startAutoLayoutLiveButton.Visibility);
+
+                this.BindCommand(ViewModel, vm => vm.StopAutoLayoutLive, v => v.stopAutoLayoutLiveButton);
+				this.WhenAnyObservable(v => v.ViewModel.StartAutoLayoutLive.IsExecuting)
+					.Select((isRunning) => isRunning ? Visibility.Visible : Visibility.Collapsed)
+					.BindTo(this, v => v.stopAutoLayoutLiveButton.Visibility);
+			});
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/Views/WindowViewBase.cs
+++ b/ExampleCodeGenPrismApp/Views/WindowViewBase.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Windows;
+using ReactiveUI;
+
+namespace ExampleCodeGenPrismApp.Views
+{
+    public class WindowViewBase<TViewModel> : ReactiveWindow<TViewModel> where TViewModel : class
+    {
+        protected CompositeDisposable CompositeDisposable { get; }
+
+        public WindowViewBase()
+        {
+            CompositeDisposable = new CompositeDisposable();
+
+            this.WhenAnyValue(v => v.DataContext)
+                .Subscribe(x => ViewModel = x as TViewModel)
+                .DisposeWith(CompositeDisposable);
+
+            this.Events().Unloaded
+                .Subscribe((_) => CompositeDisposable.Dispose())
+                .DisposeWith(CompositeDisposable);
+        }
+    }
+}

--- a/ExampleCodeGenPrismApp/packages.config
+++ b/ExampleCodeGenPrismApp/packages.config
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DynamicData" version="6.13.9" targetFramework="net47" />
+  <package id="Extended.Wpf.Toolkit" version="3.6.0" targetFramework="net47" />
+  <package id="MoonSharp" version="2.0.0.0" targetFramework="net47" />
+  <package id="ReactiveUI" version="10.3.6" targetFramework="net47" />
+  <package id="Splat" version="9.0.5" targetFramework="net47" />
+  <package id="Splat.Drawing" version="9.0.5" targetFramework="net47" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net47" />
+  <package id="System.Collections.Immutable" version="1.6.0" targetFramework="net47" />
+  <package id="System.Drawing.Primitives" version="4.3.0" targetFramework="net47" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net47" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net47" />
+  <package id="System.Reactive" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Compatibility" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Core" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Experimental" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Interfaces" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Linq" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.PlatformServices" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Providers" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Runtime.Remoting" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Windows.Forms" version="4.2.0" targetFramework="net47" />
+  <package id="System.Reactive.Windows.Threading" version="4.2.0" targetFramework="net47" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net47" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net47" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net47" />
+</packages>

--- a/NodeNetwork.sln
+++ b/NodeNetwork.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CalculatorTests", "Calculat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodeNetworkTests", "NodeNetworkTests\NodeNetworkTests.csproj", "{C80CA3BF-5F3F-48FC-B34A-1CCDD082A828}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleCodeGenPrismApp", "ExampleCodeGenPrismApp\ExampleCodeGenPrismApp.csproj", "{3ABDBB35-BABB-4BD6-BEE1-A688B06C2FF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,10 @@ Global
 		{C80CA3BF-5F3F-48FC-B34A-1CCDD082A828}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C80CA3BF-5F3F-48FC-B34A-1CCDD082A828}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C80CA3BF-5F3F-48FC-B34A-1CCDD082A828}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3ABDBB35-BABB-4BD6-BEE1-A688B06C2FF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ABDBB35-BABB-4BD6-BEE1-A688B06C2FF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3ABDBB35-BABB-4BD6-BEE1-A688B06C2FF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3ABDBB35-BABB-4BD6-BEE1-A688B06C2FF2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,6 +92,7 @@ Global
 		{69615CB9-4A6E-48A3-AAB8-9A0CABFACBB3} = {0C9292C7-07B0-45AB-A787-951C8B61AB35}
 		{6FECDB98-52C4-4153-9B69-9165585D94DD} = {0C9292C7-07B0-45AB-A787-951C8B61AB35}
 		{C80CA3BF-5F3F-48FC-B34A-1CCDD082A828} = {0C9292C7-07B0-45AB-A787-951C8B61AB35}
+		{3ABDBB35-BABB-4BD6-BEE1-A688B06C2FF2} = {EEFF7EA4-CA97-4FFE-A955-F48C8FD522A6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {923D42E4-533A-4A65-BB3E-A7CCC2585386}


### PR DESCRIPTION
This Pull-Request replaces my previous one: https://github.com/Wouterdek/NodeNetwork/pull/58

I gave up trying to make Splat any useful and maintainable within my application. Thus I went back to using Prism and solved this issue on the consumer side. Your library doesn't need any changes for this solution. However, I've provided a roughly adapted example "ExampleCodeGenPrismApp" for demonstration purpose.

The `SplatteredPrismViewLocator` is my connector between the Splat/ReactiveUI and the Prism world. Allowing me to resolve views from view models in one world, and view models from views in the other. 

The only downside to this approach is, that it removes all previously registered view model and view couplings within the Splat container. That's why I need to manually register the NodeNetwork elements within the example application as well. 

Apart from that, my approach solves the problem with generic view models as well. =)

What do you think? 