### PR TITLE
Improved connection paths

### DIFF
--- a/NodeNetwork/Views/ConnectionView.cs
+++ b/NodeNetwork/Views/ConnectionView.cs
@@ -209,8 +209,8 @@ namespace NodeNetwork.Views
                 IsClosed = false,
                 Segments =
                 {
-                    new BezierSegment(startPoint, startGradientPoint, midPoint, true),
-                    new BezierSegment(midPoint, endGradientPoint, endPoint, true)
+                    new QuadraticBezierSegment(startGradientPoint, midPoint, true),
+                    new QuadraticBezierSegment(endGradientPoint, endPoint, true)
                 }
             };
 

--- a/NodeNetwork/Views/ConnectionView.cs
+++ b/NodeNetwork/Views/ConnectionView.cs
@@ -194,8 +194,8 @@ namespace NodeNetwork.Views
             }
         }
 
-        private const double MinGradient = 100;
-        private const double WidthScaling = 25;
+        private const double MinGradient = 10;
+        private const double WidthScaling = 5;
 
         private static PathGeometry BuildSmoothBezier(Point startPoint, Vector startGradient, Point endPoint, Vector endGradient)
         {

--- a/NodeNetwork/Views/ConnectionView.cs
+++ b/NodeNetwork/Views/ConnectionView.cs
@@ -123,7 +123,12 @@ namespace NodeNetwork.Views
         private void SetupPathData()
         {
             this.WhenActivated(d => d(
-                this.WhenAny(v => v.ViewModel.Input.Port.CenterPoint, v => v.ViewModel.Output.Port.CenterPoint, (a, b) => (a, b))
+                this.WhenAny(
+                    v => v.ViewModel.Input.Port.CenterPoint, 
+                    v => v.ViewModel.Input.PortPosition,
+                    v => v.ViewModel.Output.Port.CenterPoint, 
+                    v => v.ViewModel.Output.PortPosition,
+                    (a, b, c, e) => (a, b, c, e))
                     .Select(_ 
                         => BuildSmoothBezier(
                             ViewModel.Input.Port.CenterPoint, 

--- a/NodeNetwork/Views/ConnectionView.cs
+++ b/NodeNetwork/Views/ConnectionView.cs
@@ -124,7 +124,12 @@ namespace NodeNetwork.Views
         {
             this.WhenActivated(d => d(
                 this.WhenAny(v => v.ViewModel.Input.Port.CenterPoint, v => v.ViewModel.Output.Port.CenterPoint, (a, b) => (a, b))
-                    .Select(_ => BuildSmoothBezier(ViewModel.Input.Port.CenterPoint, ViewModel.Output.Port.CenterPoint))
+                    .Select(_ 
+                        => BuildSmoothBezier(
+                            ViewModel.Input.Port.CenterPoint, 
+                            ViewModel.Input.PortPosition, 
+                            ViewModel.Output.Port.CenterPoint,
+                            ViewModel.Output.PortPosition))
                     .BindTo(this, v => v.Geometry)
             ));
         }
@@ -147,16 +152,56 @@ namespace NodeNetwork.Views
                 }).DisposeWith(d);
             });
         }
+        public static PathGeometry BuildSmoothBezier(Point startPoint, PortPosition startPosition, Point endPoint, PortPosition endPosition)
+        {
+            Vector startGradient = ToGradient(startPosition);
+            Vector endGradient = ToGradient(endPosition);
 
-        public static PathGeometry BuildSmoothBezier(Point startPoint, Point endPoint)
+            return BuildSmoothBezier(startPoint, startGradient, endPoint, endGradient);
+        }
+
+        public static PathGeometry BuildSmoothBezier(Point startPoint, PortPosition startPosition, Point endPoint)
+        {
+            Vector startGradient = ToGradient(startPosition);
+            Vector endGradient = -startGradient;
+
+            return BuildSmoothBezier(startPoint, startGradient, endPoint, endGradient);
+        }
+
+        public static PathGeometry BuildSmoothBezier(Point startPoint, Point endPoint, PortPosition endPosition)
+        {
+            Vector endGradient = ToGradient(endPosition);
+            Vector startGradient = -endGradient;
+
+            return BuildSmoothBezier(startPoint, startGradient, endPoint, endGradient);
+        }
+
+        private static Vector ToGradient(PortPosition portPosition)
+        {
+            switch (portPosition)
+            {
+                case PortPosition.Left:
+                    return new Vector(-1, 0);
+                case PortPosition.Right:
+                    return new Vector(1, 0);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private const double MinGradient = 100;
+        private const double WidthScaling = 25;
+
+        private static PathGeometry BuildSmoothBezier(Point startPoint, Vector startGradient, Point endPoint, Vector endGradient)
         {
             double width = endPoint.X - startPoint.X;
-            double height = endPoint.Y - startPoint.Y;
-            Point p1 = startPoint;
-            Point p2 = new Point(p1.X + (width / 4d), p1.Y);
-            Point p3 = new Point(p1.X + (width / 2d), p1.Y + (height / 2d));
-            Point p4 = new Point(p1.X + (3d * width / 4d), endPoint.Y);
-            Point p5 = endPoint;
+
+            var gradientScale = Math.Sqrt(Math.Abs(width) * WidthScaling + MinGradient * MinGradient);
+
+            Point startGradientPoint = startPoint + startGradient * gradientScale;
+            Point endGradientPoint = endPoint + endGradient * gradientScale;
+
+            Point midPoint = new Point((startGradientPoint.X + endGradientPoint.X) / 2d, (startPoint.Y + endPoint.Y) / 2d);
 
             PathFigure pathFigure = new PathFigure
             {
@@ -164,8 +209,8 @@ namespace NodeNetwork.Views
                 IsClosed = false,
                 Segments =
                 {
-                    new BezierSegment(p1, p2, p3, true),
-                    new BezierSegment(p3, p4, p5, true)
+                    new BezierSegment(startPoint, startGradientPoint, midPoint, true),
+                    new BezierSegment(midPoint, endGradientPoint, endPoint, true)
                 }
             };
 

--- a/NodeNetwork/Views/NetworkView.xaml.cs
+++ b/NodeNetwork/Views/NetworkView.xaml.cs
@@ -511,7 +511,7 @@ namespace NodeNetwork.Views
         {
             foreach (ConnectionViewModel con in ViewModel.Connections.Items)
             {
-                PathGeometry conGeom = ConnectionView.BuildSmoothBezier(con.Input.Port.CenterPoint, con.Output.Port.CenterPoint);
+                PathGeometry conGeom = ConnectionView.BuildSmoothBezier(con.Input.Port.CenterPoint, con.Input.PortPosition, con.Output.Port.CenterPoint, con.Output.PortPosition);
                 LineGeometry cutLineGeom = new LineGeometry(ViewModel.CutLine.StartPoint, ViewModel.CutLine.EndPoint);
                 bool hasIntersections = WPFUtils.GetIntersectionPoints(conGeom, cutLineGeom).Any();
                 yield return (con, hasIntersections);

--- a/NodeNetwork/Views/PendingConnectionView.cs
+++ b/NodeNetwork/Views/PendingConnectionView.cs
@@ -91,17 +91,21 @@ namespace NodeNetwork.Views
                         if (ViewModel.Input == null)
                         {
                             return ConnectionView.BuildSmoothBezier(ViewModel.Output.Port.CenterPoint,
+                                ViewModel.Output.PortPosition,
                                 ViewModel.LooseEndPoint);
                         }
                         else if (ViewModel.Output == null)
                         {
                             return ConnectionView.BuildSmoothBezier(ViewModel.LooseEndPoint,
-                                ViewModel.Input.Port.CenterPoint);
+                                ViewModel.Input.Port.CenterPoint,
+                                ViewModel.Input.PortPosition);
                         }
                         else
                         {
                             return ConnectionView.BuildSmoothBezier(ViewModel.Output.Port.CenterPoint,
-                                ViewModel.Input.Port.CenterPoint);
+                                ViewModel.Output.PortPosition,
+                                ViewModel.Input.Port.CenterPoint,
+                                ViewModel.Input.PortPosition);
                         }
                     })
                     .BindTo(this, v => v.Geometry)


### PR DESCRIPTION
First of all: Thanks for this great library.

I have very crowded networks, where it can get hard to see which node is connected to which other node. I think this is basically due to the way connections are drawn.

To demonstrate my point, I connected two nodes and draged one of them around:

![grafik](https://user-images.githubusercontent.com/26221781/93227853-21e34c00-f775-11ea-9173-dd4b891648d8.png) ![grafik](https://user-images.githubusercontent.com/26221781/93227918-345d8580-f775-11ea-9efe-bcbd07f2b679.png) ![grafik](https://user-images.githubusercontent.com/26221781/93227980-47705580-f775-11ea-92f8-5e332280bf08.png)

With this pull request, the connection path now starts (almost) perpendicular to the nodes side and then starts to smooth out leading to:

![grafik](https://user-images.githubusercontent.com/26221781/93228471-ce253280-f775-11ea-80ef-57e4ca5fdcb6.png) ![grafik](https://user-images.githubusercontent.com/26221781/93228535-e09f6c00-f775-11ea-9c8a-c16f1d7c6368.png) ![grafik](https://user-images.githubusercontent.com/26221781/93228685-10e70a80-f776-11ea-8751-57d8e8b677c3.png)

It even works, if inputs and outputs are on the same side:

![grafik](https://user-images.githubusercontent.com/26221781/93228924-573c6980-f776-11ea-96dd-11497b576c81.png)

This may be too much of a change to directly push it to the library, so if you would like an exchangable approach, where the previous and this approach can be exchanged, just let me know.