### PR TITLE
LayoutUpdated event replaced to improve performance.

### DIFF
--- a/NodeNetwork/Views/NetworkView.xaml
+++ b/NodeNetwork/Views/NetworkView.xaml
@@ -17,8 +17,8 @@
         <wpf:BoolToZIndexConverter x:Key="BoolToZIndexConverter"/>
     </UserControl.Resources>
     <Grid Focusable="True" KeyboardNavigation.IsTabStop="False">
-        <controls:DragCanvas Zoom="DragCanvas_OnZoom" x:Name="dragCanvas" MouseLeftButtonDown="OnClickCanvas" Background="#01000000">
-            <Canvas Name="contentContainer" LayoutUpdated="ContentContainer_OnLayoutUpdated" Width="{Binding ActualWidth, ElementName=dragCanvas}" Height="{Binding ActualHeight, ElementName=dragCanvas}">
+        <controls:DragCanvas x:Name="dragCanvas" MouseLeftButtonDown="OnClickCanvas" Background="#01000000">
+            <Canvas Name="contentContainer" Width="{Binding ActualWidth, ElementName=dragCanvas}" Height="{Binding ActualHeight, ElementName=dragCanvas}">
                 <Canvas.Clip>
                     <RectangleGeometry x:Name="clippingGeometry"/>
                 </Canvas.Clip>

--- a/NodeNetwork/Views/NetworkView.xaml.cs
+++ b/NodeNetwork/Views/NetworkView.xaml.cs
@@ -273,6 +273,13 @@ namespace NodeNetwork.Views
                 UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
             };
             _viewportBinding = BindingOperations.SetBinding(clippingGeometry, RectangleGeometry.RectProperty, binding);
+
+            this.WhenActivated(d =>
+            {
+                this.dragCanvas.WhenAnyValue(x => x.DragOffset, x => x.ZoomFactor, x => x.MaxZoomFactor, x => x.MinZoomFactor, x => x.ActualWidth, x => x.ActualHeight, x => x.RenderTransform)
+                    .Subscribe(x => this.dragCanvas.Events().LayoutUpdated.Take(1).Subscribe(y => _viewportBinding.UpdateTarget()).DisposeWith(d))
+                    .DisposeWith(d);
+            });
         }
 
         private void SetupErrorMessages()
@@ -444,18 +451,6 @@ namespace NodeNetwork.Views
 
             ViewModel.SelectionRectangle.IntersectingNodes.Clear();
             ViewModel.SelectionRectangle.IntersectingNodes.AddRange(nodesHit);
-        }
-        #endregion
-
-        #region Viewport bound updates
-        private void DragCanvas_OnZoom(object source, ZoomEventArgs args)
-        {
-            _viewportBinding?.UpdateTarget();
-        }
-
-        private void ContentContainer_OnLayoutUpdated(object sender, EventArgs e)
-        {
-            _viewportBinding?.UpdateTarget();
         }
         #endregion
 


### PR DESCRIPTION
We are using NodeNetwork control in a panel that contains a D3DImage where we render DX11 content. Each frame rendered the D3DImage fires a LayoutUpdated event (internally calls InvalidateMeasure).
We have made a quick CPU profile (using VS2019 diagnostics tools) using a network with approximately 30 nodes and 100 ports, and the LayoutUpdated event handlers in NetworkView a PortView controls consume more than 20% of CPU time. 

This PR reduces the uses of LayoutUpdated event, subscribing the event only when a related property has changed.

![image](https://user-images.githubusercontent.com/5016114/98000269-a012b500-1dec-11eb-8269-81cad122685c.png)

