### PR TITLE
Customization of keybindings for dragging, cutting and selection

### DIFF
--- a/NodeNetwork/Views/Controls/DragCanvas.cs
+++ b/NodeNetwork/Views/Controls/DragCanvas.cs
@@ -18,8 +18,8 @@ namespace NodeNetwork.Views.Controls
         /// </summary>
         public Point DragOffset
         {
-            get { return (Point)GetValue(DragOffsetProperty); }
-            set { SetValue(DragOffsetProperty, value); }
+            get => (Point)GetValue(DragOffsetProperty);
+            set => SetValue(DragOffsetProperty, value);
         }
 
         private static void DragOffsetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -60,10 +60,19 @@ namespace NodeNetwork.Views.Controls
 
         public bool IsDraggingEnabled { get; set; } = true;
 
+        #region StartDragGesture
+        public static readonly DependencyProperty StartDragGestureProperty = DependencyProperty.Register(nameof(StartDragGesture),
+            typeof(MouseGesture), typeof(DragCanvas), new PropertyMetadata(new MouseGesture(MouseAction.LeftClick)));
+
         /// <summary>
         /// This mouse gesture starts a drag on the canvas. Left click by default.
         /// </summary>
-        public MouseGesture StartDragGesture { get; set; } = new MouseGesture(MouseAction.LeftClick);
+        public MouseGesture StartDragGesture
+        {
+            get => (MouseGesture)GetValue(StartDragGestureProperty);
+            set => SetValue(StartDragGestureProperty, value);
+        }
+        #endregion
 
         /// <summary>
         /// Used when the mousebutton is down to check if the initial click was in this element.

--- a/NodeNetwork/Views/Controls/DragCanvas.cs
+++ b/NodeNetwork/Views/Controls/DragCanvas.cs
@@ -61,6 +61,11 @@ namespace NodeNetwork.Views.Controls
         public bool IsDraggingEnabled { get; set; } = true;
 
         /// <summary>
+        /// This mouse gesture starts a drag on the canvas. Left click by default.
+        /// </summary>
+        public MouseGesture StartDragGesture { get; set; } = new MouseGesture(MouseAction.LeftClick);
+
+        /// <summary>
         /// Used when the mousebutton is down to check if the initial click was in this element.
         /// This is useful because we dont want to assume a drag operation when the user moves the mouse but originally clicked a different element
         /// </summary>
@@ -85,9 +90,9 @@ namespace NodeNetwork.Views.Controls
         /// <summary> 
         /// This event puts the control into a state where it is ready for a drag operation.
         /// </summary>
-        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        protected override void OnMouseDown(MouseButtonEventArgs e)
         {
-            if (IsDraggingEnabled)
+            if (IsDraggingEnabled && StartDragGesture.Matches(this, e))
             {
                 _userClickedThisElement = true;
 
@@ -95,8 +100,6 @@ namespace NodeNetwork.Views.Controls
                 Focus();
                 CaptureMouse(); //All mouse events will now be handled by the dragcanvas
             }
-
-            base.OnMouseLeftButtonDown(e);
         }
 
         /// <summary> 
@@ -131,11 +134,10 @@ namespace NodeNetwork.Views.Controls
             base.OnMouseMove(e);
         }
 
-
         /// <summary>
-        /// Stop dragging when the user releases the left mouse button
+        /// Stop dragging when the user releases the mouse button
         /// </summary>
-        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+        protected override void OnMouseUp(MouseButtonEventArgs e)
         {
             _userClickedThisElement = false;
             ReleaseMouseCapture(); //Stop absorbing all mouse events
@@ -150,8 +152,6 @@ namespace NodeNetwork.Views.Controls
 
                 DragStop?.Invoke(this, new DragMoveEventArgs(e, xDelta, yDelta));
             }
-
-            base.OnMouseLeftButtonUp(e);
         }
 
         private void ApplyDragToChildren(double deltaX, double deltaY)

--- a/NodeNetwork/Views/NetworkView.xaml.cs
+++ b/NodeNetwork/Views/NetworkView.xaml.cs
@@ -148,6 +148,16 @@ namespace NodeNetwork.Views
         /// </example>
         public IInputElement CanvasOriginElement => contentContainer;
 
+        /// <summary>
+        /// This mouse gesture starts a cut, making the cutline visible. Right click by default.
+        /// </summary>
+        public MouseGesture StartCutGesture { get; set; } = new MouseGesture(MouseAction.RightClick);
+
+        /// <summary>
+        /// This mouse gesture starts a selection, making the selection rectangle visible. Left click + Shift by default.
+        /// </summary>
+        public MouseGesture StartSelectionRectangleGesture { get; set; } = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Shift);
+
         public NetworkView()
         {
             InitializeComponent();
@@ -211,24 +221,29 @@ namespace NodeNetwork.Views
                     isVisible => isVisible ? Visibility.Visible : Visibility.Collapsed)
                     .DisposeWith(d);
 
-                dragCanvas.Events().MouseRightButtonDown.Subscribe(e =>
+                bool cutGestured = false;
+                dragCanvas.Events().MouseDown.Subscribe(e =>
                 {
-                    Point pos = e.GetPosition(contentContainer);
-                    ViewModel.CutLine.StartPoint = pos;
-                    ViewModel.CutLine.EndPoint = pos;
-
-                    e.Handled = true;
+                    if (StartCutGesture.Matches(this, e))
+                    {
+                        Point pos = e.GetPosition(contentContainer);
+                        ViewModel.CutLine.StartPoint = pos;
+                        ViewModel.CutLine.EndPoint = pos;
+                        cutGestured = true;
+                        
+                        e.Handled = true;
+                    }
                 }).DisposeWith(d);
 
                 dragCanvas.Events().MouseMove.Subscribe(e =>
                 {
-	                if (e.RightButton == MouseButtonState.Pressed)
-	                {
-		                if (!ViewModel.CutLine.IsVisible)
-		                {
-			                ViewModel.StartCut();
-						}
+                    if (!ViewModel.CutLine.IsVisible && cutGestured)
+                    {
+                        ViewModel.StartCut();
+                    }
 
+                    if (ViewModel.CutLine.IsVisible)
+	                {
 						ViewModel.CutLine.EndPoint = e.GetPosition(contentContainer);
 
 		                ViewModel.CutLine.IntersectingConnections.Edit(l =>
@@ -242,14 +257,15 @@ namespace NodeNetwork.Views
                     
                 }).DisposeWith(d);
 
-                dragCanvas.Events().MouseRightButtonUp.Subscribe(e =>
+                dragCanvas.Events().MouseUp.Subscribe(e =>
                 {
-	                if (ViewModel.CutLine.IsVisible)
+                    cutGestured = false;
+                    if (ViewModel.CutLine.IsVisible)
 	                {
 		                //Do cuts
 		                ViewModel.FinishCut();
 
-		                e.Handled = true;
+                        e.Handled = true;
 	                }
                 }).DisposeWith(d);
             });
@@ -371,7 +387,7 @@ namespace NodeNetwork.Views
 
                 this.Events().PreviewMouseDown.Subscribe(e =>
                 {
-                    if (ViewModel != null && e.ChangedButton == MouseButton.Left && Keyboard.IsKeyDown(Key.LeftShift))
+                    if (ViewModel != null && StartSelectionRectangleGesture.Matches(this, e))
                     {
                         CaptureMouse();
                         dragCanvas.IsDraggingEnabled = false;

--- a/NodeNetwork/Views/NetworkView.xaml.cs
+++ b/NodeNetwork/Views/NetworkView.xaml.cs
@@ -148,15 +148,33 @@ namespace NodeNetwork.Views
         /// </example>
         public IInputElement CanvasOriginElement => contentContainer;
 
+        #region StartCutGesture
+        public static readonly DependencyProperty StartCutGestureProperty = DependencyProperty.Register(nameof(StartCutGesture),
+            typeof(MouseGesture), typeof(NetworkView), new PropertyMetadata(new MouseGesture(MouseAction.RightClick)));
+
         /// <summary>
         /// This mouse gesture starts a cut, making the cutline visible. Right click by default.
         /// </summary>
-        public MouseGesture StartCutGesture { get; set; } = new MouseGesture(MouseAction.RightClick);
+        public MouseGesture StartCutGesture
+        {
+            get => (MouseGesture)GetValue(StartCutGestureProperty);
+            set => SetValue(StartCutGestureProperty, value);
+        }
+        #endregion
+
+        #region StartSelectionRectangleGesture
+        public static readonly DependencyProperty StartSelectionRectangleGestureProperty = DependencyProperty.Register(nameof(StartSelectionRectangleGesture),
+            typeof(MouseGesture), typeof(NetworkView), new PropertyMetadata(new MouseGesture(MouseAction.LeftClick, ModifierKeys.Shift)));
 
         /// <summary>
         /// This mouse gesture starts a selection, making the selection rectangle visible. Left click + Shift by default.
         /// </summary>
-        public MouseGesture StartSelectionRectangleGesture { get; set; } = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Shift);
+        public MouseGesture StartSelectionRectangleGesture
+        {
+            get => (MouseGesture)GetValue(StartSelectionRectangleGestureProperty);
+            set => SetValue(StartSelectionRectangleGestureProperty, value);
+        }
+        #endregion
 
         public NetworkView()
         {


### PR DESCRIPTION
Added mouse gesture properties to dragcanvas and networkview to allow customization of the keybindings for dragging, cutting and selection.

For example: to set the cutting keybinding to left click + shift, set `StartCutGesture` as follows:

```csharp
networkView.StartCutGesture = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Shift);
```