### PR TITLE
Fixed endpoint group behavior on collapsing of the node. 

### DIFF
--- a/NodeNetwork/ViewModels/NodeViewModel.cs
+++ b/NodeNetwork/ViewModels/NodeViewModel.cs
@@ -305,13 +305,11 @@ namespace NodeNetwork.ViewModels
             var allInputGroups
                 = visibilityFilteredInputs
                     .TransformMany(GetAllGroupsInHierarchy)
-                    .DistinctValues(g => g)
                     .AddKey(g => g);
 
             var allOutputGroups
                 = visibilityFilteredOutputs
                     .TransformMany(GetAllGroupsInHierarchy)
-                    .DistinctValues(g => g)
                     .AddKey(g => g);
 
             IEnumerable<EndpointGroup> GetAllGroupsInHierarchy(Endpoint endpoint)
@@ -325,7 +323,10 @@ namespace NodeNetwork.ViewModels
             }
 
             // Merge needs AddKey first, otherwise removal of endpoints leads to confusion.
-            var allGroups = allInputGroups.Merge(allOutputGroups);
+            var allGroups 
+                = allInputGroups
+                    .Merge(allOutputGroups)
+                    .DistinctValues(g => g);
 
             // Used as temporary root for TransformToTree.
             var root = new EndpointGroup();

--- a/NodeNetworkTests/EndpointGroupingTests.cs
+++ b/NodeNetworkTests/EndpointGroupingTests.cs
@@ -114,7 +114,7 @@ namespace NodeNetworkTests
             Assert.AreEqual(outputA2, groupAViewModel.VisibleOutputs.Items.ElementAt(1));
 
             node.Inputs.Remove(inputB2);
-            node.Outputs.RemoveMany(new []{outputB1, outputB1});
+            node.Outputs.RemoveMany(new []{outputB1, outputB2});
 
             Assert.IsTrue(node.VisibleInputs.Count == 0);
             Assert.IsTrue(node.VisibleEndpointGroups.Count == 1);
@@ -196,6 +196,49 @@ namespace NodeNetworkTests
             Assert.AreEqual(inputD, groupDViewModel.VisibleInputs.Items.First());
             Assert.IsTrue(groupDViewModel.VisibleOutputs.Count == 1);
             Assert.AreEqual(outputD, groupDViewModel.VisibleOutputs.Items.First());
+        }
+
+        [TestMethod]
+        public void TestCollapseWithGroups()
+        {
+            NodeViewModel node = new NodeViewModel();
+
+            EndpointGroup groupA = new EndpointGroup { Name = "Group A" };
+            EndpointGroup groupB = new EndpointGroup { Name = "Group B" };
+            EndpointGroup groupC = new EndpointGroup(groupA) { Name = "Group C" };
+            EndpointGroup groupD = new EndpointGroup(groupB) { Name = "Group D" };
+            
+            NodeInputViewModel inputC = new NodeInputViewModel { Group = groupC, Name = "Input C"};
+            NodeOutputViewModel outputC = new NodeOutputViewModel { Group = groupC, Name = "Output C" };
+
+            NodeInputViewModel inputD = new NodeInputViewModel { Group = groupD, Name = "Input D" };
+            NodeOutputViewModel outputD = new NodeOutputViewModel { Group = groupD, Name = "Output D" };
+
+            node.Inputs.Add(inputC);
+            node.Inputs.Add(inputD);
+            node.Outputs.Add(outputC);
+            node.Outputs.Add(outputD);
+
+            var network = new NetworkViewModel();
+            network.Nodes.Add(node);
+            network.Connections.Add(network.ConnectionFactory(inputC, new NodeOutputViewModel()));
+
+            node.IsCollapsed = true;
+
+            Assert.IsTrue(node.VisibleInputs.Count == 0);
+            Assert.IsTrue(node.VisibleOutputs.Count == 0);
+            Assert.IsTrue(node.VisibleEndpointGroups.Count == 1);
+
+            EndpointGroupViewModel groupAViewModel = node.VisibleEndpointGroups[0];
+            Assert.AreEqual(groupA, groupAViewModel.Group);
+            Assert.IsTrue(groupAViewModel.VisibleInputs.Count == 0);
+            Assert.IsTrue(groupAViewModel.VisibleOutputs.Count == 0);
+            Assert.IsTrue(groupAViewModel.Children.Count == 1);
+            EndpointGroupViewModel groupCViewModel = groupAViewModel.Children[0];
+            Assert.AreEqual(groupC, groupCViewModel.Group);
+            Assert.IsTrue(groupCViewModel.VisibleInputs.Count == 1);
+            Assert.AreEqual(inputC, groupCViewModel.VisibleInputs.Items.First());
+            Assert.IsTrue(groupCViewModel.VisibleOutputs.Count == 0);
         }
     }
 }


### PR DESCRIPTION
When collapsing a node endpoints of an endpoint group were vanishing even if they were connected. Fixed the issue. Added test and fixed another.