### PR TITLE
Moved MenuItem DataTemplate to resources to fix issue #98.

### DIFF
--- a/NodeNetworkToolkit/ContextMenu/SearchableContextMenuView.xaml
+++ b/NodeNetworkToolkit/ContextMenu/SearchableContextMenuView.xaml
@@ -14,12 +14,10 @@
                 <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
             </Style.Setters>
         </Style>
-    </ContextMenu.Resources>
-    <ContextMenu.ItemTemplate>
         <DataTemplate DataType="{x:Type local:LabeledCommand}">
             <TextBlock><Run Text="{Binding Label}"/></TextBlock>
         </DataTemplate>
-    </ContextMenu.ItemTemplate>
+    </ContextMenu.Resources>
     <ContextMenu.ItemsSource>
         <CompositeCollection>
             <MenuItem x:Name="SearchMenuItem" StaysOpenOnClick="True">


### PR DESCRIPTION
Moved DataTemplate to the resources of the context menu to prevent WPF binding error.