### PR TITLE
pulled enum out that had restricted access via generic type

### DIFF
--- a/NodeNetworkToolkit/ValueNode/ValidationAction.cs
+++ b/NodeNetworkToolkit/ValueNode/ValidationAction.cs
@@ -1,0 +1,26 @@
+﻿namespace NodeNetwork.Toolkit.ValueNode
+{
+
+    /// <summary>
+    /// Action that should be taken based on the validation result
+    /// </summary>
+    public enum ValidationAction
+    {
+        /// <summary>
+        /// Don't run the validation. (LatestValidation is not updated)
+        /// </summary>
+        DontValidate,
+        /// <summary>
+        /// Run the validation, but ignore the result and assume the network is valid.
+        /// </summary>
+        IgnoreValidation,
+        /// <summary>
+        /// Run the validation and if the network is invalid then wait until it is valid.
+        /// </summary>
+        WaitForValid,
+        /// <summary>
+        /// Run the validation and if the network is invalid then make default(T) the current value.
+        /// </summary>
+        PushDefaultValue
+    }
+}

--- a/NodeNetworkToolkit/ValueNode/ValueNodeInputViewModel.cs
+++ b/NodeNetworkToolkit/ValueNode/ValueNodeInputViewModel.cs
@@ -46,29 +46,6 @@ namespace NodeNetwork.Toolkit.ValueNode
         #endregion
 
         /// <summary>
-        /// Action that should be taken based on the validation result
-        /// </summary>
-        public enum ValidationAction
-        {
-            /// <summary>
-            /// Don't run the validation. (LatestValidation is not updated)
-            /// </summary>
-            DontValidate,
-            /// <summary>
-            /// Run the validation, but ignore the result and assume the network is valid.
-            /// </summary>
-            IgnoreValidation,
-            /// <summary>
-            /// Run the validation and if the network is invalid then wait until it is valid.
-            /// </summary>
-            WaitForValid,
-            /// <summary>
-            /// Run the validation and if the network is invalid then make default(T) the current value.
-            /// </summary>
-            PushDefaultValue
-        }
-
-        /// <summary>
         /// Constructs a new ValueNodeInputViewModel with the specified ValidationActions. 
         /// The default values are carefully chosen and should probably not be changed unless you know what you are doing.
         /// </summary>


### PR DESCRIPTION
Needed access to that enum without having to specify generic type on ValueNodeInputViewModel. Was just easiest to completely pull the enum out. Not sure if restricting access to the enum was on purpose or just a side-effect.