### PR TITLE
AddEndpointFromPendingConnection removes PendingConnection from Network

### DIFF
--- a/NodeNetworkToolkit/Group/AddEndpointDropPanel/AddEndpointDropPanelViewModel.cs
+++ b/NodeNetworkToolkit/Group/AddEndpointDropPanel/AddEndpointDropPanelViewModel.cs
@@ -51,6 +51,7 @@ namespace NodeNetwork.Toolkit.Group.AddEndpointDropPanel
             {
                 var network = isOnSubnet ? NodeGroupIOBinding.SubNetwork : NodeGroupIOBinding.SuperNetwork;
                 var pendingConn = network.PendingConnection;
+                network.RemovePendingConnection();
 
                 NodeInputViewModel input = null;
                 NodeOutputViewModel output = null;


### PR DESCRIPTION
I had the problem, that when I combine the AddNodeFromPendingConnection context menu with the AddEndpointDropPanel, that the connection was correctly created for the GroupIoNode, but after that the context menu poped up. I had no way of telling that AddEndpointDropPanel has already taken care of the PendingConnection.

With this PR this is fixed, by removing the pending connection from the NetworkViewModel.